### PR TITLE
ci: enforce version of Maven

### DIFF
--- a/.github/scripts/change_versions.sh
+++ b/.github/scripts/change_versions.sh
@@ -6,7 +6,6 @@
 #
 # The current version is necessary, because at this point, the script has no way of knowing what the current version is.
 # It cannot be read from the POM, as the POM would have to be resolved and the upstream SNAPSHOT is not available.
-
 find . -name pom.xml | xargs sed -i "s/$CURRENT_VERSION/$NEW_VERSION/g"
 find . -name build.gradle | xargs sed -i "s/$CURRENT_VERSION/$NEW_VERSION/g"
 find . -name pom.xml | xargs git add

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.9.3
+
       # No need to wait for the upstream release to show up in Maven Central.
       - name: Build the upstream release tag
         working-directory: "./timefold-solver"


### PR DESCRIPTION
`MAVEN_ARGS` is only supported since 3.9.0.