### PR TITLE
fix: disable enforcer even when run from quarkus:dev

### DIFF
--- a/build/.mvn/maven.config
+++ b/build/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Denforcer.skip=true


### PR DESCRIPTION
For reasons unknown to me, quarkus:dev causes enforcer to execute, 
but does not give enforcer the Maven properties we use to disable enforcer.
And because we know that enforcer fails with Quarkus projects,
this caused the project to fail if (and only if) run in Quarkus dev mode.

This may be a regression in Quarkus, as it only started happening recently.