### PR TITLE
fix: disable enforcer even when run from quarkus:dev

### DIFF
--- a/build/.mvn/maven.config
+++ b/build/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Denforcer.skip=true


### PR DESCRIPTION
See https://github.com/TimefoldAI/timefold-quickstarts/pull/82.