### PR TITLE
bug: Fix placing of markers when new dataset is loaded

### DIFF
--- a/use-cases/vehicle-routing-capacity/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/vehicle-routing-capacity/src/main/resources/META-INF/resources/app.js
@@ -238,7 +238,10 @@ function fetchDemoData() {
                 switchDataDropDownItemActive(item);
                 scheduleId = null;
                 demoDataId = item;
-
+                depotGroup.clearLayers();
+                depotMarkerByIdMap.clear();
+                customerGroup.clearLayers();
+                customerMarkerByIdMap.clear();
                 refreshRoutePlan();
             });
         });

--- a/use-cases/vehicle-routing-time-windows/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/vehicle-routing-time-windows/src/main/resources/META-INF/resources/app.js
@@ -400,6 +400,10 @@ function fetchDemoData() {
                 scheduleId = null;
                 demoDataId = item;
                 initialized = false;
+                depotGroup.clearLayers();
+                depotMarkerByIdMap.clear();
+                customerGroup.clearLayers();
+                customerMarkerByIdMap.clear();
                 refreshRoutePlan();
             });
         });


### PR DESCRIPTION
When switching data sets, the markers were not cleared correctly before being placed with the new dataset resulting in wrong visualisations