### PR TITLE
fix:Renaming variable names for collection types

### DIFF
--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/rest/TimetableResource.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/rest/TimetableResource.java
@@ -1,5 +1,10 @@
 package org.acme.schooltimetabling.rest;
 
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
@@ -21,12 +26,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "School Timetables", description = "School timetable service assigning lessons to rooms and timeslots.")
 @RestController
@@ -81,7 +89,8 @@ public class TimetableResource {
                     description = "Resulting score analysis, optionally without constraint matches.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ScoreAnalysis.class)))})
     @PutMapping(value = "/analyze", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ScoreAnalysis<HardSoftScore> analyze(@RequestBody Timetable problem, @RequestParam("fetchPolicy") ScoreAnalysisFetchPolicy fetchPolicy) {
+    public ScoreAnalysis<HardSoftScore> analyze(@RequestBody Timetable problem,
+                                                @RequestParam(name = "fetchPolicy", required = false) ScoreAnalysisFetchPolicy fetchPolicy) {
         return fetchPolicy == null ? solutionManager.analyze(problem) : solutionManager.analyze(problem, fetchPolicy);
     }
 

--- a/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Employee.java
+++ b/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Employee.java
@@ -16,15 +16,15 @@ public class Employee {
     String name;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    Set<String> skillSet;
+    Set<String> skills;
 
     public Employee() {
 
     }
 
-    public Employee(String name, Set<String> skillSet) {
+    public Employee(String name, Set<String> skills) {
         this.name = name;
-        this.skillSet = skillSet;
+        this.skills = skills;
     }
 
     public String getName() {
@@ -35,12 +35,12 @@ public class Employee {
         this.name = name;
     }
 
-    public Set<String> getSkillSet() {
-        return skillSet;
+    public Set<String> getSkills() {
+        return skills;
     }
 
-    public void setSkillSet(Set<String> skillSet) {
-        this.skillSet = skillSet;
+    public void setSkills(Set<String> skills) {
+        this.skills = skills;
     }
 
     @Override

--- a/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/EmployeeSchedule.java
+++ b/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/EmployeeSchedule.java
@@ -13,14 +13,14 @@ import ai.timefold.solver.core.api.solver.SolverStatus;
 @PlanningSolution
 public class EmployeeSchedule {
     @ProblemFactCollectionProperty
-    List<Availability> availabilityList;
+    List<Availability> availabilities;
 
     @ProblemFactCollectionProperty
     @ValueRangeProvider
-    List<Employee> employeeList;
+    List<Employee> employees;
 
     @PlanningEntityCollectionProperty
-    List<Shift> shiftList;
+    List<Shift> shifts;
 
     @PlanningScore
     HardSoftScore score;
@@ -32,11 +32,11 @@ public class EmployeeSchedule {
     // No-arg constructor required for Timefold
     public EmployeeSchedule() {}
 
-    public EmployeeSchedule(ScheduleState scheduleState, List<Availability> availabilityList, List<Employee> employeeList, List<Shift> shiftList) {
+    public EmployeeSchedule(ScheduleState scheduleState, List<Availability> availabilities, List<Employee> employees, List<Shift> shifts) {
         this.scheduleState = scheduleState;
-        this.availabilityList = availabilityList;
-        this.employeeList = employeeList;
-        this.shiftList = shiftList;
+        this.availabilities = availabilities;
+        this.employees = employees;
+        this.shifts = shifts;
     }
 
     public ScheduleState getScheduleState() {
@@ -47,28 +47,28 @@ public class EmployeeSchedule {
         this.scheduleState = scheduleState;
     }
 
-    public List<Availability> getAvailabilityList() {
-        return availabilityList;
+    public List<Availability> getAvailabilities() {
+        return availabilities;
     }
 
-    public void setAvailabilityList(List<Availability> availabilityList) {
-        this.availabilityList = availabilityList;
+    public void setAvailabilities(List<Availability> availabilities) {
+        this.availabilities = availabilities;
     }
 
-    public List<Employee> getEmployeeList() {
-        return employeeList;
+    public List<Employee> getEmployees() {
+        return employees;
     }
 
-    public void setEmployeeList(List<Employee> employeeList) {
-        this.employeeList = employeeList;
+    public void setEmployees(List<Employee> employees) {
+        this.employees = employees;
     }
 
-    public List<Shift> getShiftList() {
-        return shiftList;
+    public List<Shift> getShifts() {
+        return shifts;
     }
 
-    public void setShiftList(List<Shift> shiftList) {
-        this.shiftList = shiftList;
+    public void setShifts(List<Shift> shifts) {
+        this.shifts = shifts;
     }
 
     public HardSoftScore getScore() {

--- a/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/rest/EmployeeScheduleResource.java
+++ b/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/rest/EmployeeScheduleResource.java
@@ -106,7 +106,7 @@ public class EmployeeScheduleResource {
 
     @Transactional
     protected void save(EmployeeSchedule schedule) {
-        for (Shift shift : schedule.getShiftList()) {
+        for (Shift shift : schedule.getShifts()) {
             // TODO this is awfully naive: optimistic locking causes issues if called by the SolverManager
             Shift attachedShift = shiftRepository.findById(shift.getId());
             attachedShift.setEmployee(shift.getEmployee());

--- a/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
+++ b/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
@@ -45,7 +45,7 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
 
     Constraint requiredSkill(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(Shift.class)
-                .filter(shift -> !shift.getEmployee().getSkillSet().contains(shift.getRequiredSkill()))
+                .filter(shift -> !shift.getEmployee().getSkills().contains(shift.getRequiredSkill()))
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Missing required skill");
     }

--- a/use-cases/employee-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/employee-scheduling/src/main/resources/META-INF/resources/app.js
@@ -155,7 +155,7 @@ function refreshSchedule() {
         byLocationTimeline.setCustomTime(schedule.scheduleState.lastHistoricDate, 'published');
         byLocationTimeline.setCustomTime(schedule.scheduleState.firstDraftDate, 'draft');
 
-        schedule.availabilityList.forEach((availability, index) => {
+        schedule.availabilities.forEach((availability, index) => {
             const availabilityDate = JSJoda.LocalDate.parse(availability.date);
             const start = availabilityDate.atStartOfDay().toString();
             const end = availabilityDate.plusDays(1).atStartOfDay().toString();
@@ -173,16 +173,16 @@ function refreshSchedule() {
         });
 
 
-        schedule.employeeList.forEach((employee, index) => {
+        schedule.employees.forEach((employee, index) => {
             const employeeGroupElement = $('<div class="card-body p-2"/>')
                     .append($(`<h5 class="card-title mb-2"/>)`)
                             .append(employee.name))
                     .append($('<div/>')
-                            .append($(employee.skillSet.map(skill => `<span class="badge me-1 mt-1" style="background-color:#d3d7cf">${skill}</span>`).join(''))));
+                            .append($(employee.skills.map(skill => `<span class="badge me-1 mt-1" style="background-color:#d3d7cf">${skill}</span>`).join(''))));
             byEmployeeGroupDataSet.add({id : employee.name, content: employeeGroupElement.html()});
         });
 
-        schedule.shiftList.forEach((shift, index) => {
+        schedule.shifts.forEach((shift, index) => {
             if (groups.indexOf(shift.location) === -1) {
                 groups.push(shift.location);
                 byLocationGroupDataSet.add({
@@ -207,7 +207,7 @@ function refreshSchedule() {
                     style: "background-color: #EF292999"
                 });
             } else {
-                const skillColor = (shift.employee.skillSet.indexOf(shift.requiredSkill) === -1? '#ef2929' : '#8ae234');
+                const skillColor = (shift.employee.skills.indexOf(shift.requiredSkill) === -1? '#ef2929' : '#8ae234');
                 const byEmployeeShiftElement = $('<div class="card-body p-2"/>')
                         .append($(`<h5 class="card-title mb-2"/>)`)
                                 .append(shift.location))

--- a/use-cases/employee-scheduling/src/test/java/org/acme/employeescheduling/rest/EmployeeScheduleResourceTest.java
+++ b/use-cases/employee-scheduling/src/test/java/org/acme/employeescheduling/rest/EmployeeScheduleResourceTest.java
@@ -32,8 +32,8 @@ public class EmployeeScheduleResourceTest {
             Thread.sleep(20L);
             employeeSchedule = employeeScheduleResource.getSchedule();
         }
-        assertFalse(employeeSchedule.getShiftList().isEmpty());
-        for (Shift shift : employeeSchedule.getShiftList()) {
+        assertFalse(employeeSchedule.getShifts().isEmpty());
+        for (Shift shift : employeeSchedule.getShifts()) {
             assertNotNull(shift.getEmployee());
         }
         assertTrue(employeeSchedule.getScore().isFeasible());

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/bootstrap/DemoDataGenerator.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/bootstrap/DemoDataGenerator.java
@@ -85,9 +85,9 @@ public class DemoDataGenerator {
                         : cleaningMinutesMinimum + random.nextInt(cleaningMinutesMaximum - cleaningMinutesMinimum));
                 cleaningDurationMap.put(previousProduct, cleaningDuration);
             }
-            product.setCleaningDurationMap(cleaningDurationMap);
+            product.setCleaningDurations(cleaningDurationMap);
         }
-        solution.setProductList(productList);
+        solution.setProducts(productList);
 
         List<Line> lineList = new ArrayList<>(lineCount);
         for (int i = 0; i < lineCount; i++) {
@@ -95,7 +95,7 @@ public class DemoDataGenerator {
             String operator = "Operator " + ((char) ('A' + (i / 2)));
             lineList.add(new Line((long) i, name, operator, START_DATE_TIME));
         }
-        solution.setLineList(lineList);
+        solution.setLines(lineList);
 
         List<Job> jobList = new ArrayList<>(jobCount);
         for (int i = 0; i < jobCount; i++) {
@@ -110,7 +110,7 @@ public class DemoDataGenerator {
             jobList.add(new Job((long) i, name, product, duration, readyDateTime, idealEndDateTime, dueDateTime, 1, false));
         }
         jobList.sort(Comparator.comparing(Job::getName));
-        solution.setJobList(jobList);
+        solution.setJobs(jobList);
 
         repository.write(solution);
     }

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Job.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Job.java
@@ -31,13 +31,13 @@ public class Job {
     @PlanningPin
     private boolean pinned;
 
-    @InverseRelationShadowVariable(sourceVariableName = "jobList")
+    @InverseRelationShadowVariable(sourceVariableName = "jobs")
     private Line line;
     @JsonIgnore
-    @PreviousElementShadowVariable(sourceVariableName = "jobList")
+    @PreviousElementShadowVariable(sourceVariableName = "jobs")
     private Job previousJob;
     @JsonIgnore
-    @NextElementShadowVariable(sourceVariableName = "jobList")
+    @NextElementShadowVariable(sourceVariableName = "jobs")
     private Job nextJob;
 
     /** Start is after cleanup. */

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Line.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Line.java
@@ -18,7 +18,7 @@ public class Line {
 
     @JsonIgnore
     @PlanningListVariable
-    private List<Job> jobList;
+    private List<Job> jobs;
 
     // No-arg constructor required for OptaPlanner and Jackson
     public Line() {
@@ -29,7 +29,7 @@ public class Line {
         this.name = name;
         this.operator = operator;
         this.startDateTime = startDateTime;
-        jobList = new ArrayList<>();
+        jobs = new ArrayList<>();
     }
 
     @Override
@@ -57,8 +57,8 @@ public class Line {
         return startDateTime;
     }
 
-    public List<Job> getJobList() {
-        return jobList;
+    public List<Job> getJobs() {
+        return jobs;
     }
 
 }

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/PackagingSchedule.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/PackagingSchedule.java
@@ -18,14 +18,14 @@ public class PackagingSchedule {
     private WorkCalendar workCalendar;
 
     @ProblemFactCollectionProperty
-    private List<Product> productList;
+    private List<Product> products;
 
     @PlanningEntityCollectionProperty
-    private List<Line> lineList;
+    private List<Line> lines;
 
     @PlanningEntityCollectionProperty
     @ValueRangeProvider
-    private List<Job> jobList;
+    private List<Job> jobs;
 
     @PlanningScore
     private HardMediumSoftLongScore score;
@@ -49,28 +49,28 @@ public class PackagingSchedule {
         this.workCalendar = workCalendar;
     }
 
-    public List<Product> getProductList() {
-        return productList;
+    public List<Product> getProducts() {
+        return products;
     }
 
-    public void setProductList(List<Product> productList) {
-        this.productList = productList;
+    public void setProducts(List<Product> products) {
+        this.products = products;
     }
 
-    public List<Line> getLineList() {
-        return lineList;
+    public List<Line> getLines() {
+        return lines;
     }
 
-    public void setLineList(List<Line> lineList) {
-        this.lineList = lineList;
+    public void setLines(List<Line> lines) {
+        this.lines = lines;
     }
 
-    public List<Job> getJobList() {
-        return jobList;
+    public List<Job> getJobs() {
+        return jobs;
     }
 
-    public void setJobList(List<Job> jobList) {
-        this.jobList = jobList;
+    public void setJobs(List<Job> jobs) {
+        this.jobs = jobs;
     }
 
     public HardMediumSoftLongScore getScore() {

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Product.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Product.java
@@ -8,7 +8,7 @@ public class Product {
     private Long id;
     private String name;
     /** The map key is previous product on assembly line. */
-    private Map<Product, Duration> cleaningDurationMap;
+    private Map<Product, Duration> cleaningDurations;
 
     // No-arg constructor required for OptaPlanner and Jackson
     public Product() {
@@ -25,7 +25,7 @@ public class Product {
     }
 
     public Duration getCleanupDuration(Product previousProduct) {
-        Duration cleanupDuration = cleaningDurationMap.get(previousProduct);
+        Duration cleanupDuration = cleaningDurations.get(previousProduct);
         if (cleanupDuration == null) {
             throw new IllegalArgumentException("Cleanup duration previousProduct (" + previousProduct
                     + ") to toProduct (" + this + ") is missing.");
@@ -49,12 +49,12 @@ public class Product {
         this.name = name;
     }
 
-    public Map<Product, Duration> getCleaningDurationMap() {
-        return cleaningDurationMap;
+    public Map<Product, Duration> getCleaningDurations() {
+        return cleaningDurations;
     }
 
-    public void setCleaningDurationMap(Map<Product, Duration> cleaningDurationMap) {
-        this.cleaningDurationMap = cleaningDurationMap;
+    public void setCleaningDurations(Map<Product, Duration> cleaningDurations) {
+        this.cleaningDurations = cleaningDurations;
     }
 
 }

--- a/use-cases/food-packaging/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/food-packaging/src/main/resources/META-INF/resources/app.js
@@ -67,14 +67,14 @@ function refreshSchedule() {
     byLineItemDataSet.clear();
     byJobItemDataSet.clear();
 
-    $.each(schedule.lineList, (index, line) => {
+    $.each(schedule.lines, (index, line) => {
       const lineGroupElement = $(`<div/>`)
         .append($(`<h5 class="card-title mb-1"/>`).text(line.name))
         .append($(`<p class="card-text ms-2 mb-0"/>`).text(line.operator));
       byLineGroupDataSet.add({id : line.id, content: lineGroupElement.html()});
     });
 
-    $.each(schedule.jobList, (index, job) => {
+    $.each(schedule.jobs, (index, job) => {
       byJobGroupDataSet.add({id : job.id, content: job.name});
       byJobItemDataSet.add({
         id: job.id + "_readyToIdealEnd", group: job.id,

--- a/use-cases/food-packaging/src/test/java/org/acme/foodpackaging/solver/FoodPackagingConstraintProviderTest.java
+++ b/use-cases/food-packaging/src/test/java/org/acme/foodpackaging/solver/FoodPackagingConstraintProviderTest.java
@@ -26,13 +26,13 @@ class FoodPackagingConstraintProviderTest {
     public static final Product PRODUCT_B = new Product(2L, "Product B");
 
     static {
-        PRODUCT_A_SMALL.setCleaningDurationMap(Map.of(
+        PRODUCT_A_SMALL.setCleaningDurations(Map.of(
                 PRODUCT_A_LARGE, Duration.ofMinutes(5),
                 PRODUCT_B, Duration.ofMinutes(60)));
-        PRODUCT_A_LARGE.setCleaningDurationMap(Map.of(
+        PRODUCT_A_LARGE.setCleaningDurations(Map.of(
                 PRODUCT_A_SMALL, Duration.ofMinutes(0),
                 PRODUCT_B, Duration.ofMinutes(60)));
-        PRODUCT_B.setCleaningDurationMap(Map.of(
+        PRODUCT_B.setCleaningDurations(Map.of(
                 PRODUCT_A_SMALL, Duration.ofMinutes(40),
                 PRODUCT_A_LARGE, Duration.ofMinutes(40)));
     }
@@ -138,7 +138,7 @@ class FoodPackagingConstraintProviderTest {
         for (int i = 0; i < jobs.length; i++) {
             Job job = jobs[i];
             job.setLine(line);
-            line.getJobList().add(job);
+            line.getJobs().add(job);
             if (i > 0) {
                 job.setPreviousJob(jobs[i - 1]);
             }

--- a/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/Job.java
+++ b/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/Job.java
@@ -30,7 +30,7 @@ public class Job {
     private LocalDate idealEndDate; // Exclusive
 
     @ElementCollection(fetch = FetchType.EAGER)
-    private Set<String> tagSet;
+    private Set<String> tags;
 
     @PlanningVariable
     @ManyToOne
@@ -45,16 +45,16 @@ public class Job {
     public Job() {
     }
 
-    public Job(String name, int durationInDays, LocalDate readyDate, LocalDate dueDate, LocalDate idealEndDate, Set<String> tagSet) {
+    public Job(String name, int durationInDays, LocalDate readyDate, LocalDate dueDate, LocalDate idealEndDate, Set<String> tags) {
         this.name = name;
         this.durationInDays = durationInDays;
         this.readyDate = readyDate;
         this.dueDate = dueDate;
         this.idealEndDate = idealEndDate;
-        this.tagSet = tagSet;
+        this.tags = tags;
     }
 
-    public Job(Long id, String name, int durationInDays, LocalDate readyDate, LocalDate dueDate, LocalDate idealEndDate, Set<String> tagSet,
+    public Job(Long id, String name, int durationInDays, LocalDate readyDate, LocalDate dueDate, LocalDate idealEndDate, Set<String> tags,
             Crew crew, LocalDate startDate) {
         this.id = id;
         this.name = name;
@@ -62,7 +62,7 @@ public class Job {
         this.readyDate = readyDate;
         this.dueDate = dueDate;
         this.idealEndDate = idealEndDate;
-        this.tagSet = tagSet;
+        this.tags = tags;
         this.crew = crew;
         this.startDate = startDate;
         this.endDate = EndDateUpdatingVariableListener.calculateEndDate(startDate, durationInDays);
@@ -102,8 +102,8 @@ public class Job {
         return idealEndDate;
     }
 
-    public Set<String> getTagSet() {
-        return tagSet;
+    public Set<String> getTags() {
+        return tags;
     }
 
     public Crew getCrew() {

--- a/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/MaintenanceSchedule.java
+++ b/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/MaintenanceSchedule.java
@@ -21,9 +21,9 @@ public class MaintenanceSchedule {
     private WorkCalendar workCalendar;
     @ProblemFactCollectionProperty
     @ValueRangeProvider
-    private List<Crew> crewList;
+    private List<Crew> crews;
     @PlanningEntityCollectionProperty
-    private List<Job> jobList;
+    private List<Job> jobs;
 
     @PlanningScore
     private HardSoftLongScore score;
@@ -36,10 +36,10 @@ public class MaintenanceSchedule {
     }
 
     public MaintenanceSchedule(WorkCalendar workCalendar,
-            List<Crew> crewList, List<Job> jobList) {
+                               List<Crew> crews, List<Job> jobs) {
         this.workCalendar = workCalendar;
-        this.crewList = crewList;
-        this.jobList = jobList;
+        this.crews = crews;
+        this.jobs = jobs;
     }
 
     @ValueRangeProvider
@@ -61,12 +61,12 @@ public class MaintenanceSchedule {
         return workCalendar;
     }
 
-    public List<Crew> getCrewList() {
-        return crewList;
+    public List<Crew> getCrews() {
+        return crews;
     }
 
-    public List<Job> getJobList() {
-        return jobList;
+    public List<Job> getJobs() {
+        return jobs;
     }
 
     public HardSoftLongScore getScore() {

--- a/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/rest/MaintenanceScheduleResource.java
+++ b/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/rest/MaintenanceScheduleResource.java
@@ -78,7 +78,7 @@ public class MaintenanceScheduleResource {
 
     @Transactional
     protected void save(MaintenanceSchedule schedule) {
-        for (Job job : schedule.getJobList()) {
+        for (Job job : schedule.getJobs()) {
             // TODO this is awfully naive: optimistic locking causes issues if called by the SolverManager
             Job attachedJob = jobRepository.findById(job.getId());
             attachedJob.setCrew(job.getCrew());

--- a/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/solver/MaintenanceScheduleConstraintProvider.java
+++ b/use-cases/maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/solver/MaintenanceScheduleConstraintProvider.java
@@ -101,11 +101,11 @@ public class MaintenanceScheduleConstraintProvider implements ConstraintProvider
                         overlapping(Job::getStartDate, Job::getEndDate),
                         // TODO Use intersecting() when available https://github.com/TimefoldAI/timefold-solver/issues/8
                         filtering((job1, job2) -> !Collections.disjoint(
-                                job1.getTagSet(), job2.getTagSet())))
+                                job1.getTags(), job2.getTags())))
                 .penalizeLong(HardSoftLongScore.ofSoft(1_000),
                         (job1, job2) -> {
-                            Set<String> intersection = new HashSet<>(job1.getTagSet());
-                            intersection.retainAll(job2.getTagSet());
+                            Set<String> intersection = new HashSet<>(job1.getTags());
+                            intersection.retainAll(job2.getTags());
                             long overlap = DAYS.between(
                                     job1.getStartDate().isAfter(job2.getStartDate())
                                             ? job1.getStartDate()  : job2.getStartDate(),

--- a/use-cases/maintenance-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/maintenance-scheduling/src/main/resources/META-INF/resources/app.js
@@ -65,11 +65,11 @@ function refreshSchedule() {
         byCrewItemDataSet.clear();
         byJobItemDataSet.clear();
 
-        $.each(schedule.crewList, (index, crew) => {
+        $.each(schedule.crews, (index, crew) => {
             byCrewGroupDataSet.add({id : crew.id, content: crew.name});
         });
 
-        $.each(schedule.jobList, (index, job) => {
+        $.each(schedule.jobs, (index, job) => {
             const jobGroupElement = $(`<div/>`)
               .append($(`<h5 class="card-title mb-1"/>`).text(job.name))
               .append($(`<p class="card-text ms-2 mb-0"/>`).text(`${job.durationInDays} workdays`));
@@ -99,7 +99,7 @@ function refreshSchedule() {
                     .append($(`<p class="card-text ms-2 mb-0"/>`).text(`Due: ${job.dueDate}`));
                 const byJobJobElement = $(`<div/>`)
                   .append($(`<h5 class="card-title mb-1"/>`).text(`Unassigned`));
-                $.each(job.tagSet, (index, tag) => {
+                $.each(job.tags, (index, tag) => {
                     const color = pickColor(tag);
                     unassignedJobElement.append($(`<span class="badge me-1" style="background-color: ${color}"/>`).text(tag));
                     byJobJobElement.append($(`<span class="badge me-1" style="background-color: ${color}"/>`).text(tag));
@@ -127,7 +127,7 @@ function refreshSchedule() {
                     byCrewJobElement.append($(`<p class="badge badge-danger mb-0"/>`).text(`After due (too late)`));
                     byJobJobElement.append($(`<p class="badge badge-danger mb-0"/>`).text(`After due (too late)`));
                 }
-                $.each(job.tagSet, (index, tag) => {
+                $.each(job.tags, (index, tag) => {
                     const color = pickColor(tag);
                     byCrewJobElement.append($(`<span class="badge me-1" style="background-color: ${color}"/>`).text(tag));
                     byJobJobElement.append($(`<span class="badge me-1" style="background-color: ${color}"/>`).text(tag));

--- a/use-cases/maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/rest/MaintenanceScheduleResourceTest.java
+++ b/use-cases/maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/rest/MaintenanceScheduleResourceTest.java
@@ -32,8 +32,8 @@ public class MaintenanceScheduleResourceTest {
             Thread.sleep(20L);
             maintenanceSchedule = maintenanceScheduleResource.getSchedule();
         }
-        assertFalse(maintenanceSchedule.getJobList().isEmpty());
-        for (Job job : maintenanceSchedule.getJobList()) {
+        assertFalse(maintenanceSchedule.getJobs().isEmpty());
+        for (Job job : maintenanceSchedule.getJobs()) {
             assertNotNull(job.getCrew());
             assertNotNull(job.getStartDate());
         }

--- a/use-cases/order-picking/src/main/java/org/acme/orderpicking/domain/OrderPickingPlanning.java
+++ b/use-cases/order-picking/src/main/java/org/acme/orderpicking/domain/OrderPickingPlanning.java
@@ -23,7 +23,7 @@ public class OrderPickingPlanning {
         this.solverStatus = solverStatus;
         this.solution = solution;
         this.solverWasNeverStarted = solverWasNeverStarted;
-        for (Trolley trolley : solution.getTrolleyList()) {
+        for (Trolley trolley : solution.getTrolleys()) {
             distanceToTravelByTrolley.put(trolley.getId(), Warehouse.calculateDistanceToTravel(trolley));
         }
     }

--- a/use-cases/order-picking/src/main/java/org/acme/orderpicking/domain/OrderPickingSolution.java
+++ b/use-cases/order-picking/src/main/java/org/acme/orderpicking/domain/OrderPickingSolution.java
@@ -19,7 +19,7 @@ public class OrderPickingSolution {
      */
     @ValueRangeProvider
     @ProblemFactCollectionProperty
-    private List<Trolley> trolleyList;
+    private List<Trolley> trolleys;
 
     /**
      * Defines the available TrolleySteps.
@@ -28,7 +28,7 @@ public class OrderPickingSolution {
      */
     @ValueRangeProvider
     @PlanningEntityCollectionProperty
-    private List<TrolleyStep> trolleyStepList;
+    private List<TrolleyStep> trolleySteps;
 
     @PlanningScore
     private HardSoftLongScore score;
@@ -37,25 +37,25 @@ public class OrderPickingSolution {
         // Marshalling constructor
     }
 
-    public OrderPickingSolution(List<Trolley> trolleyList, List<TrolleyStep> trolleyStepList) {
-        this.trolleyList = trolleyList;
-        this.trolleyStepList = trolleyStepList;
+    public OrderPickingSolution(List<Trolley> trolleys, List<TrolleyStep> trolleySteps) {
+        this.trolleys = trolleys;
+        this.trolleySteps = trolleySteps;
     }
 
-    public List<Trolley> getTrolleyList() {
-        return trolleyList;
+    public List<Trolley> getTrolleys() {
+        return trolleys;
     }
 
-    public void setTrolleyList(List<Trolley> trolleyList) {
-        this.trolleyList = trolleyList;
+    public void setTrolleys(List<Trolley> trolleys) {
+        this.trolleys = trolleys;
     }
 
-    public List<TrolleyStep> getTrolleyStepList() {
-        return trolleyStepList;
+    public List<TrolleyStep> getTrolleySteps() {
+        return trolleySteps;
     }
 
-    public void setTrolleyStepList(List<TrolleyStep> trolleyStepList) {
-        this.trolleyStepList = trolleyStepList;
+    public void setTrolleySteps(List<TrolleyStep> trolleySteps) {
+        this.trolleySteps = trolleySteps;
     }
 
     public HardSoftLongScore getScore() {

--- a/use-cases/order-picking/src/main/java/org/acme/orderpicking/domain/TrolleyStep.java
+++ b/use-cases/order-picking/src/main/java/org/acme/orderpicking/domain/TrolleyStep.java
@@ -35,9 +35,9 @@ public class TrolleyStep extends TrolleyOrTrolleyStep {
      * Planning variable: changes during planning, between score calculations.
      * <p>
      * The Trolleys for building the chains are taken from the value range provider
-     * {@link OrderPickingSolution#getTrolleyList()}.
+     * {@link OrderPickingSolution#getTrolleys()}.
      * The intermediary elements, the TrolleySteps, for building the chains are taken from the value range provider
-     * {@link OrderPickingSolution#getTrolleyStepList()}.
+     * {@link OrderPickingSolution#getTrolleySteps()}.
      */
     @JsonIgnore
     @PlanningVariable(graphType = PlanningVariableGraphType.CHAINED)

--- a/use-cases/order-picking/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/order-picking/src/main/resources/META-INF/resources/app.js
@@ -48,7 +48,7 @@ function printSolutionTable(orderPickingSolution) {
     const unassignedItemsByOrder = unassignedOrderItemsAndOrdersSpreading[0];
     const trolleysByOrder = unassignedOrderItemsAndOrdersSpreading[1];
     const unassignedTrolleys = [];
-    for (const trolley of orderPickingSolution.trolleyList) {
+    for (const trolley of orderPickingSolution.trolleys) {
         if (trolley.nextElement != null) {
             const travelDistance = TROLLEY_TRAVEL_DISTANCE.get(trolley.id);
             printTrolley(tableBody, trolley, travelDistance, unassignedItemsByOrder, trolleysByOrder);
@@ -167,7 +167,7 @@ function printUnassignedOrderRow(unassignedOrderTableBody, orderItem) {
 function findUnassignedOrderItemsAndOrdersSpreading(orderPickingSolution) {
     const unassignedItemsByOrder = new Map();
     const trolleysByOrder = new Map();
-    for (const trolleyStep of orderPickingSolution.trolleyStepList) {
+    for (const trolleyStep of orderPickingSolution.trolleySteps) {
         const orderItem = trolleyStep.orderItem;
         if (trolleyStep.trolleyId === null) {
             let unassignedItems = unassignedItemsByOrder.get(orderItem.orderId);
@@ -394,16 +394,16 @@ function printTrolleysMap(orderPickingSolution) {
     mapActionsContainer.children().remove();
     const trolleyCheckBoxes = [];
     let trolleyIndex = 0;
-    for (const trolley of orderPickingSolution.trolleyList) {
+    for (const trolley of orderPickingSolution.trolleys) {
         if (trolley.nextElement != null) {
-            printTrolleyPath(trolley, trolleyIndex, orderPickingSolution.trolleyList.length, false);
+            printTrolleyPath(trolley, trolleyIndex, orderPickingSolution.trolleys.length, false);
             trolleyCheckBoxes.push(trolley.id);
         }
         trolleyIndex++;
     }
-    for (const trolley of orderPickingSolution.trolleyList) {
+    for (const trolley of orderPickingSolution.trolleys) {
         if (trolley.nextElement != null) {
-            printTrolleyPath(trolley, trolleyIndex, orderPickingSolution.trolleyList.length, true);
+            printTrolleyPath(trolley, trolleyIndex, orderPickingSolution.trolleys.length, true);
             trolleyCheckBoxes.push(trolley.id);
         }
         trolleyIndex++;

--- a/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/domain/VaccinationSchedule.java
+++ b/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/domain/VaccinationSchedule.java
@@ -8,17 +8,17 @@ import ai.timefold.solver.core.api.solver.SolverStatus;
 
 public class VaccinationSchedule {
 
-    private List<VaccineType> vaccineTypeList;
+    private List<VaccineType> vaccineTypes;
 
-    private List<VaccinationCenter> vaccinationCenterList;
+    private List<VaccinationCenter> vaccinationCenters;
 
     /**
-     * Translated to {@link VaccinationSolution#getVaccinationCenterList()} before solving and back again after solving.
+     * Translated to {@link VaccinationSolution#getVaccinationCenters()} before solving and back again after solving.
      * See {@link VaccinationSolution#VaccinationSolution(VaccinationSchedule)} and {@link VaccinationSolution#toSchedule()}.
      */
-    private List<Appointment> appointmentList;
+    private List<Appointment> appointments;
 
-    private List<Person> personList;
+    private List<Person> people;
 
     private BendableLongScore score;
 
@@ -28,32 +28,32 @@ public class VaccinationSchedule {
     public VaccinationSchedule() {
     }
 
-    public VaccinationSchedule(List<VaccineType> vaccineTypeList, List<VaccinationCenter> vaccinationCenterList,
-            List<Appointment> appointmentList, List<Person> personList) {
-        this.vaccineTypeList = vaccineTypeList;
-        this.vaccinationCenterList = vaccinationCenterList;
-        this.appointmentList = appointmentList;
-        this.personList = personList;
+    public VaccinationSchedule(List<VaccineType> vaccineTypes, List<VaccinationCenter> vaccinationCenters,
+                               List<Appointment> appointments, List<Person> people) {
+        this.vaccineTypes = vaccineTypes;
+        this.vaccinationCenters = vaccinationCenters;
+        this.appointments = appointments;
+        this.people = people;
     }
 
     // ************************************************************************
     // Getters and setters
     // ************************************************************************
 
-    public List<VaccineType> getVaccineTypeList() {
-        return vaccineTypeList;
+    public List<VaccineType> getVaccineTypes() {
+        return vaccineTypes;
     }
 
-    public List<VaccinationCenter> getVaccinationCenterList() {
-        return vaccinationCenterList;
+    public List<VaccinationCenter> getVaccinationCenters() {
+        return vaccinationCenters;
     }
 
-    public List<Appointment> getAppointmentList() {
-        return appointmentList;
+    public List<Appointment> getAppointments() {
+        return appointments;
     }
 
-    public List<Person> getPersonList() {
-        return personList;
+    public List<Person> getPeople() {
+        return people;
     }
 
     public BendableLongScore getScore() {

--- a/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/domain/solver/PersonAssignment.java
+++ b/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/domain/solver/PersonAssignment.java
@@ -22,7 +22,7 @@ public class PersonAssignment {
 
     private Person person;
 
-    private Map<VaccinationCenter, Long> distanceMap;
+    private Map<VaccinationCenter, Long> distances;
     private Long nearestVaccinationCenterDistance;
 
     /**
@@ -37,39 +37,39 @@ public class PersonAssignment {
     public PersonAssignment() {
     }
 
-    public PersonAssignment(Person person, Map<VaccinationCenter, Long> distanceMap) {
+    public PersonAssignment(Person person, Map<VaccinationCenter, Long> distances) {
         this.person = person;
-        this.distanceMap = distanceMap;
-        if (distanceMap != null) {
-            nearestVaccinationCenterDistance = distanceMap.values().stream().mapToLong(Long::valueOf).min().orElse(0);
+        this.distances = distances;
+        if (distances != null) {
+            nearestVaccinationCenterDistance = distances.values().stream().mapToLong(Long::valueOf).min().orElse(0);
         }
     }
 
     public PersonAssignment(PersonAssignment original) {
         this.person = original.person;
-        this.distanceMap = original.distanceMap;
+        this.distances = original.distances;
         this.nearestVaccinationCenterDistance = original.nearestVaccinationCenterDistance;
         this.vaccinationSlot = original.vaccinationSlot;
     }
 
-    public PersonAssignment(String id, String name, Location homeLocation, Map<VaccinationCenter, Long> distanceMap, LocalDate birthdate, long priorityRating, VaccinationSlot vaccinationSlot) {
-        this(new Person(id, name, homeLocation, birthdate, priorityRating), distanceMap);
+    public PersonAssignment(String id, String name, Location homeLocation, Map<VaccinationCenter, Long> distances, LocalDate birthdate, long priorityRating, VaccinationSlot vaccinationSlot) {
+        this(new Person(id, name, homeLocation, birthdate, priorityRating), distances);
         this.vaccinationSlot = vaccinationSlot;
     }
 
-    public PersonAssignment(String id, String name, Location homeLocation, Map<VaccinationCenter, Long> distanceMap, LocalDate birthdate, long priorityRating,
-            int doseNumber, VaccineType requiredVaccineType, VaccineType preferredVaccineType,
-            VaccinationCenter requiredVaccinationCenter, VaccinationCenter preferredVaccinationCenter,
-            LocalDate readyDate, LocalDate idealDate, LocalDate dueDate,
-            VaccinationSlot vaccinationSlot) {
+    public PersonAssignment(String id, String name, Location homeLocation, Map<VaccinationCenter, Long> distances, LocalDate birthdate, long priorityRating,
+                            int doseNumber, VaccineType requiredVaccineType, VaccineType preferredVaccineType,
+                            VaccinationCenter requiredVaccinationCenter, VaccinationCenter preferredVaccinationCenter,
+                            LocalDate readyDate, LocalDate idealDate, LocalDate dueDate,
+                            VaccinationSlot vaccinationSlot) {
         this(new Person(id, name, homeLocation, birthdate, priorityRating, doseNumber,
                 requiredVaccineType, preferredVaccineType, requiredVaccinationCenter, preferredVaccinationCenter,
-                readyDate, idealDate, dueDate), distanceMap);
+                readyDate, idealDate, dueDate), distances);
         this.vaccinationSlot = vaccinationSlot;
     }
 
     public long getDistanceTo(VaccinationCenter vaccinationCenter) {
-        Long distance = distanceMap.get(vaccinationCenter);
+        Long distance = distances.get(vaccinationCenter);
         if (distance == null) {
             throw new IllegalStateException("The person (" + person
                     + ") is lacking a distance to vaccination center (" + vaccinationCenter + ").");

--- a/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/domain/solver/VaccinationSlot.java
+++ b/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/domain/solver/VaccinationSlot.java
@@ -24,17 +24,17 @@ public class VaccinationSlot {
     private LocalTime startTime;
     private VaccineType vaccineType;
 
-    private List<Appointment> unscheduledAppointmentList;
+    private List<Appointment> unscheduledAppointments;
     private int capacity;
 
     public VaccinationSlot(Long id, VaccinationCenter vaccinationCenter,
-            LocalDateTime startDateTime, VaccineType vaccineType, List<Appointment> unscheduledAppointmentList, int capacity) {
+                           LocalDateTime startDateTime, VaccineType vaccineType, List<Appointment> unscheduledAppointments, int capacity) {
         this.id = id;
         this.vaccinationCenter = vaccinationCenter;
         this.date = startDateTime.toLocalDate();
         this.startTime = startDateTime.toLocalTime();
         this.vaccineType = vaccineType;
-        this.unscheduledAppointmentList = unscheduledAppointmentList;
+        this.unscheduledAppointments = unscheduledAppointments;
         this.capacity = capacity;
     }
 
@@ -46,7 +46,7 @@ public class VaccinationSlot {
         this.date = startDateTime == null ? null : startDateTime.toLocalDate();
         this.startTime = startDateTime == null ? null : startDateTime.toLocalTime();
         this.vaccineType = vaccineType;
-        unscheduledAppointmentList = null;
+        unscheduledAppointments = null;
         this.capacity = capacity;
     }
 
@@ -84,8 +84,8 @@ public class VaccinationSlot {
         return vaccineType;
     }
 
-    public List<Appointment> getUnscheduledAppointmentList() {
-        return unscheduledAppointmentList;
+    public List<Appointment> getUnscheduledAppointments() {
+        return unscheduledAppointments;
     }
 
     public int getCapacity() {

--- a/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/rest/VaccinationScheduleSolverResource.java
+++ b/use-cases/vaccination-scheduling/src/main/java/org/acme/vaccinationscheduler/rest/VaccinationScheduleSolverResource.java
@@ -49,21 +49,21 @@ public class VaccinationScheduleSolverResource {
             if (page < 0) {
                 throw new IllegalArgumentException("Unsupported page (" + page + ").");
             }
-            int appointmentListSize = schedule.getAppointmentList().size();
+            int appointmentListSize = schedule.getAppointments().size();
             if (appointmentListSize > APPOINTMENT_PAGE_LIMIT) {
-                List<VaccineType> vaccineTypeList = schedule.getVaccineTypeList();
-                List<VaccinationCenter> vaccinationCenterList = schedule.getVaccinationCenterList();
+                List<VaccineType> vaccineTypeList = schedule.getVaccineTypes();
+                List<VaccinationCenter> vaccinationCenterList = schedule.getVaccinationCenters();
                 List<Appointment> appointmentList;
                 List<Person> personList;
                 if (appointmentListSize <= APPOINTMENT_PAGE_LIMIT) {
-                    appointmentList = schedule.getAppointmentList();
-                    personList = schedule.getPersonList();
+                    appointmentList = schedule.getAppointments();
+                    personList = schedule.getPeople();
                 } else {
                     Map<VaccinationCenter, Set<String>> boothIdSetMap = new HashMap<>(vaccinationCenterList.size());
                     for (VaccinationCenter vaccinationCenter : vaccinationCenterList) {
                         boothIdSetMap.put(vaccinationCenter, new LinkedHashSet<>());
                     }
-                    for (Appointment appointment : schedule.getAppointmentList()) {
+                    for (Appointment appointment : schedule.getAppointments()) {
                         Set<String> boothIdSet = boothIdSetMap.get(appointment.getVaccinationCenter());
                         boothIdSet.add(appointment.getBoothId());
                     }
@@ -76,11 +76,11 @@ public class VaccinationScheduleSolverResource {
                                 boothIdList.subList(page * pageLength,
                                         Math.min(boothIdList.size(), (page + 1) * pageLength))));
                     });
-                    appointmentList = schedule.getAppointmentList().stream()
+                    appointmentList = schedule.getAppointments().stream()
                             .filter(appointment -> subBoothIdSetMap.get(appointment.getVaccinationCenter())
                                     .contains(appointment.getBoothId()))
                             .collect(Collectors.toList());
-                    personList = schedule.getPersonList().stream()
+                    personList = schedule.getPeople().stream()
                             .filter(person -> person.getAppointment() != null
                                     && subBoothIdSetMap.get(person.getAppointment().getVaccinationCenter())
                                     .contains(person.getAppointment().getBoothId()))

--- a/use-cases/vaccination-scheduling/src/test/java/org/acme/vaccinationscheduler/domain/solver/VaccinationSolutionTest.java
+++ b/use-cases/vaccination-scheduling/src/test/java/org/acme/vaccinationscheduler/domain/solver/VaccinationSolutionTest.java
@@ -49,9 +49,9 @@ class VaccinationSolutionTest {
         assertTrue(solution.getPersonAssignmentList().isEmpty());
 
         schedule = solution.toSchedule();
-        assertEquals(0, schedule.getPersonList().size());
-        assertTrue(schedule.getAppointmentList().isEmpty());
-        assertTrue(schedule.getPersonList().isEmpty());
+        assertEquals(0, schedule.getPeople().size());
+        assertTrue(schedule.getAppointments().isEmpty());
+        assertTrue(schedule.getPeople().isEmpty());
     }
 
     @Test
@@ -97,7 +97,7 @@ class VaccinationSolutionTest {
         personAssignmentList.get(0).setVaccinationSlot(vaccinationSlotList.get(1));
         personAssignmentList.get(2).setVaccinationSlot(vaccinationSlotList.get(2));
         schedule = solution.toSchedule();
-        assertEquals(3, schedule.getPersonList().size());
+        assertEquals(3, schedule.getPeople().size());
         assertSame(vc1_13_0900, ann.getAppointment());
         assertNull(beth.getAppointment());
         assertSame(vc2_21_0900, carl.getAppointment());
@@ -149,7 +149,7 @@ class VaccinationSolutionTest {
         personAssignmentList.get(2).setVaccinationSlot(vaccinationSlotList.get(0));
         personAssignmentList.get(3).setVaccinationSlot(vaccinationSlotList.get(0));
         schedule = solution.toSchedule();
-        assertEquals(6, schedule.getPersonList().size());
+        assertEquals(6, schedule.getPeople().size());
         assertSame(vc1_11_0910, ann.getAppointment());
         assertNull(beth.getAppointment());
         assertSame(vc1_11_0900, carl.getAppointment());
@@ -191,7 +191,7 @@ class VaccinationSolutionTest {
         assertEquals("Carl", personAssignmentList.get(2).getName());
 
         schedule = solution.toSchedule();
-        assertEquals(3, schedule.getPersonList().size());
+        assertEquals(3, schedule.getPeople().size());
         assertSame(vc1_11_0900, ann.getAppointment());
         assertSame(vc1_11_0900, beth.getAppointment());
         assertSame(vc1_11_0910, carl.getAppointment());

--- a/use-cases/vehicle-routing-capacity/src/main/java/org/acme/vehiclerouting/domain/Location.java
+++ b/use-cases/vehicle-routing-capacity/src/main/java/org/acme/vehiclerouting/domain/Location.java
@@ -14,7 +14,7 @@ public class Location {
     private double longitude;
 
     @JsonIgnore
-    private Map<Location, Long> distanceMap;
+    private Map<Location, Long> distances;
 
     @JsonCreator
     public Location(@JsonProperty("latitude") double latitude, @JsonProperty("longitude") double longitude) {
@@ -30,17 +30,17 @@ public class Location {
         return longitude;
     }
 
-    public Map<Location, Long> getDistanceMap() {
-        return distanceMap;
+    public Map<Location, Long> getDistances() {
+        return distances;
     }
 
     /**
      * Set the distance map. Distances are in meters.
      *
-     * @param distanceMap a map containing distances from here to other locations
+     * @param distances a map containing distances from here to other locations
      */
-    public void setDistanceMap(Map<Location, Long> distanceMap) {
-        this.distanceMap = distanceMap;
+    public void setDistances(Map<Location, Long> distances) {
+        this.distances = distances;
     }
 
     /**
@@ -50,7 +50,7 @@ public class Location {
      * @return distance in meters
      */
     public long getDistanceTo(Location location) {
-        return distanceMap.get(location);
+        return distances.get(location);
     }
 
     // ************************************************************************

--- a/use-cases/vehicle-routing-capacity/src/main/java/org/acme/vehiclerouting/domain/geo/DistanceCalculator.java
+++ b/use-cases/vehicle-routing-capacity/src/main/java/org/acme/vehiclerouting/domain/geo/DistanceCalculator.java
@@ -45,6 +45,6 @@ public interface DistanceCalculator {
      */
     default void initDistanceMaps(Collection<Location> locations) {
         Map<Location, Map<Location, Long>> distanceMatrix = calculateBulkDistance(locations, locations);
-        locations.forEach(location -> location.setDistanceMap(distanceMatrix.get(location)));
+        locations.forEach(location -> location.setDistances(distanceMatrix.get(location)));
     }
 }

--- a/use-cases/vehicle-routing-time-windows/src/main/java/org/acme/vehiclerouting/domain/Location.java
+++ b/use-cases/vehicle-routing-time-windows/src/main/java/org/acme/vehiclerouting/domain/Location.java
@@ -14,7 +14,7 @@ public class Location {
     private double longitude;
 
     @JsonIgnore
-    private Map<Location, Long> drivingTimeSecondsMap;
+    private Map<Location, Long> drivingTimeSeconds;
 
     @JsonCreator
     public Location(@JsonProperty("latitude") double latitude, @JsonProperty("longitude") double longitude) {
@@ -30,17 +30,17 @@ public class Location {
         return longitude;
     }
 
-    public Map<Location, Long> getDrivingTimeSecondsMap() {
-        return drivingTimeSecondsMap;
+    public Map<Location, Long> getDrivingTimeSeconds() {
+        return drivingTimeSeconds;
     }
 
     /**
      * Set the driving time map (in seconds).
      *
-     * @param drivingTimeSecondsMap a map containing driving time from here to other locations
+     * @param drivingTimeSeconds a map containing driving time from here to other locations
      */
-    public void setDrivingTimeSecondsMap(Map<Location, Long> drivingTimeSecondsMap) {
-        this.drivingTimeSecondsMap = drivingTimeSecondsMap;
+    public void setDrivingTimeSeconds(Map<Location, Long> drivingTimeSeconds) {
+        this.drivingTimeSeconds = drivingTimeSeconds;
     }
 
     /**
@@ -50,7 +50,7 @@ public class Location {
      * @return driving time in seconds
      */
     public long getDrivingTimeTo(Location location) {
-        return drivingTimeSecondsMap.get(location);
+        return drivingTimeSeconds.get(location);
     }
 
     @Override

--- a/use-cases/vehicle-routing-time-windows/src/main/java/org/acme/vehiclerouting/domain/geo/DistanceCalculator.java
+++ b/use-cases/vehicle-routing-time-windows/src/main/java/org/acme/vehiclerouting/domain/geo/DistanceCalculator.java
@@ -43,6 +43,6 @@ public interface DistanceCalculator {
      */
     default void initDistanceMaps(Collection<Location> locations) {
         Map<Location, Map<Location, Long>> distanceMatrix = calculateBulkDistance(locations, locations);
-        locations.forEach(location -> location.setDrivingTimeSecondsMap(distanceMatrix.get(location)));
+        locations.forEach(location -> location.setDrivingTimeSeconds(distanceMatrix.get(location)));
     }
 }


### PR DESCRIPTION
This pull request updates variable names for collection types using the following patterns: `<name>List`, `<name>Set`, and `<name>Map`.

Regarding the `timefold-solver` repository, only the name `shiftList` needs to be updated, and I'll create a separate PR to address that.

Issue #19 