### PR TITLE
deps: do not depend on Maven Compiler in Kotlin

### DIFF
--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -15,7 +15,6 @@
     <version.kotlin>1.9.21</version.kotlin>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
-    <version.compiler.plugin>3.11.0</version.compiler.plugin>
     <version.surefire.plugin>3.2.3</version.surefire.plugin>
   </properties>
 
@@ -150,10 +149,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
The dependency is optional, and upgrade to Compiler 3.12 seems to fail. Therefore, removing the dependency, leaving Kotlin to deal with it on its own.

Replaces https://github.com/TimefoldAI/timefold-quickstarts/pull/201