### PR TITLE
fix: Accepting feasible solutions and avoid inconsistent state

### DIFF
--- a/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
@@ -6,6 +6,7 @@ import java.util.EnumSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -41,7 +42,8 @@ public class DataGenerator {
     }
 
     public CallCenter generateCallCenter() {
-        return new CallCenter(EnumSet.allOf(Skill.class), Arrays.asList(AGENTS), new ArrayList<>());
+        return new CallCenter(EnumSet.allOf(Skill.class), Arrays.stream(AGENTS).map(Agent::copy).collect(Collectors.toList()),
+                new ArrayList<>());
     }
 
     public Call generateCall(int durationSeconds) {

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
@@ -3,13 +3,12 @@ package org.acme.callcenter.data;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
-
 import org.acme.callcenter.domain.Agent;
 import org.acme.callcenter.domain.Call;
 import org.acme.callcenter.domain.CallCenter;
@@ -22,17 +21,6 @@ public class DataGenerator {
 
     private final Random RANDOM = new Random(37);
 
-    private static final Agent[] AGENTS = new Agent[] {
-            new Agent(nextId(), "Ann", buildSkillSet(Skill.ENGLISH, Skill.LIFE_INSURANCE, Skill.PROPERTY_INSURANCE)),
-            new Agent(nextId(), "Beth", buildSkillSet(Skill.ENGLISH, Skill.SPANISH, Skill.CAR_INSURANCE)),
-            new Agent(nextId(), "Carl", buildSkillSet(Skill.ENGLISH, Skill.PROPERTY_INSURANCE)),
-            new Agent(nextId(), "Dennis", buildSkillSet(Skill.SPANISH, Skill.LIFE_INSURANCE)),
-            new Agent(nextId(), "Elsa", buildSkillSet(Skill.SPANISH, Skill.CAR_INSURANCE, Skill.PROPERTY_INSURANCE)),
-            new Agent(nextId(), "Francis", buildSkillSet(Skill.SPANISH, Skill.PROPERTY_INSURANCE)),
-            new Agent(nextId(), "Gus", buildSkillSet(Skill.GERMAN, Skill.ENGLISH, Skill.LIFE_INSURANCE)),
-            new Agent(nextId(), "Hugo", buildSkillSet(Skill.GERMAN, Skill.CAR_INSURANCE, Skill.PROPERTY_INSURANCE))
-    };
-
     private static final Skill[] LANGUAGE_SKILLS = new Skill[] { Skill.ENGLISH, Skill.SPANISH, Skill.GERMAN };
     private static final Skill[] PRODUCT_SKILLS =
             new Skill[] { Skill.CAR_INSURANCE, Skill.LIFE_INSURANCE, Skill.PROPERTY_INSURANCE };
@@ -42,8 +30,17 @@ public class DataGenerator {
     }
 
     public CallCenter generateCallCenter() {
-        return new CallCenter(EnumSet.allOf(Skill.class), Arrays.stream(AGENTS).map(Agent::copy).collect(Collectors.toList()),
-                new ArrayList<>());
+        List<Agent> agents = List.of(
+                new Agent(nextId(), "Ann", buildSkillSet(Skill.ENGLISH, Skill.LIFE_INSURANCE, Skill.PROPERTY_INSURANCE)),
+                new Agent(nextId(), "Beth", buildSkillSet(Skill.ENGLISH, Skill.SPANISH, Skill.CAR_INSURANCE)),
+                new Agent(nextId(), "Carl", buildSkillSet(Skill.ENGLISH, Skill.PROPERTY_INSURANCE)),
+                new Agent(nextId(), "Dennis", buildSkillSet(Skill.SPANISH, Skill.LIFE_INSURANCE)),
+                new Agent(nextId(), "Elsa", buildSkillSet(Skill.SPANISH, Skill.CAR_INSURANCE, Skill.PROPERTY_INSURANCE)),
+                new Agent(nextId(), "Francis", buildSkillSet(Skill.SPANISH, Skill.PROPERTY_INSURANCE)),
+                new Agent(nextId(), "Gus", buildSkillSet(Skill.GERMAN, Skill.ENGLISH, Skill.LIFE_INSURANCE)),
+                new Agent(nextId(), "Hugo", buildSkillSet(Skill.GERMAN, Skill.CAR_INSURANCE, Skill.PROPERTY_INSURANCE))
+        );
+        return new CallCenter(EnumSet.allOf(Skill.class), agents, new ArrayList<>());
     }
 
     public Call generateCall(int durationSeconds) {

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/domain/Agent.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/domain/Agent.java
@@ -57,8 +57,4 @@ public class Agent extends PreviousCallOrAgent {
     public Set<Skill> getSkills() {
         return skills;
     }
-
-    public Agent copy() {
-        return new Agent(getId(), name, skills);
-    }
 }

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/domain/Agent.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/domain/Agent.java
@@ -57,4 +57,8 @@ public class Agent extends PreviousCallOrAgent {
     public Set<Skill> getSkills() {
         return skills;
     }
+
+    public Agent copy() {
+        return new Agent(getId(), name, skills);
+    }
 }

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
@@ -45,7 +45,7 @@ public class SolverService {
     public void startSolving(CallCenter inputProblem,
             Consumer<CallCenter> bestSolutionConsumer, Consumer<Throwable> errorHandler) {
         solverManager.solveAndListen(SINGLETON_ID, id -> inputProblem, bestSolution -> {
-            if (bestSolution.getScore().isSolutionInitialized()) {
+            if (bestSolution.getScore().isSolutionInitialized() && bestSolution.isFeasible()) {
                 bestSolutionConsumer.accept(bestSolution);
                 pinCallAssignedToAgents(bestSolution.getCalls());
             }

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
@@ -45,7 +45,7 @@ public class SolverService {
     public void startSolving(CallCenter inputProblem,
             Consumer<CallCenter> bestSolutionConsumer, Consumer<Throwable> errorHandler) {
         solverManager.solveAndListen(SINGLETON_ID, id -> inputProblem, bestSolution -> {
-            if (bestSolution.getScore().isSolutionInitialized() && bestSolution.isFeasible()) {
+            if (bestSolution.isFeasible()) {
                 bestSolutionConsumer.accept(bestSolution);
                 pinCallAssignedToAgents(bestSolution.getCalls());
             }


### PR DESCRIPTION
This pull request enhances `org.acme.callcenter.service.SolverService#startSolving` logic to ensure the solution is feasible before pinning it. Also, `org.acme. call center.data.DataGenerator#generateCallCenter` is now copying the agents to avoid sharing the instances, which results in inconsistent states.