### PR TITLE
fix: Adding `settings.gradle` file

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'Timefold Solver Quickstarts'
+include ':hello-world'
+include ':technology:java-spring-boot'
+include ':use-cases:school-timetabling'

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -9,7 +9,12 @@ def timefoldVersion = "999-SNAPSHOT"
 group = "org.acme"
 archivesBaseName = "timefold-solver-spring-boot-school-timetabling-quickstart"
 version = "1.0-SNAPSHOT"
-sourceCompatibility = "17"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This PR adds the file `settings.gradle` and configures two subprojects: `hello-world` and `technology/java-spring-boot`. No Gradle project is found at the root level, causing Dependabot to fail to upgrade dependencies. The issue is resolved by adding the settings file with the required submodules.

Issue #190 

![Screenshot at 2023-12-22 15-51-01](https://github.com/TimefoldAI/timefold-quickstarts/assets/11961659/e8181f1a-3886-4d6e-97b4-c479cb17ca58)
