### PR TITLE
fix: Updating Maven variable name

### DIFF
--- a/hello-world/pom.xml
+++ b/hello-world/pom.xml
@@ -15,7 +15,7 @@
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
     <version.org.assertj>3.25.1</version.org.assertj>
     <version.org.junit.jupiter>5.10.1</version.org.junit.jupiter>
-    <version.org.logback>1.4.14</version.org.logback>
+    <version.ch.qos.logback>1.4.14</version.ch.qos.logback>
 
     <version.compiler.plugin>3.12.1</version.compiler.plugin>
     <version.surefire.plugin>3.2.3</version.surefire.plugin>
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>${version.org.logback}</version>
+        <version>${version.ch.qos.logback}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR updates the `logback` Maven variable name to `version.ch.qos.logback`.

Issue #216