### PR TITLE
feat: Support Spring Boot native image

### DIFF
--- a/technology/java-spring-boot/README.adoc
+++ b/technology/java-spring-boot/README.adoc
@@ -79,6 +79,80 @@ To run it on port 8081 instead, add `-Dserver.port=8081`.
 
 . Click on the *Solve* button.
 
+[[native]]
+== Create a native image
+
+
+IMPORTANT: The solver runs considerably slower in a native image.
+
+If you want faster startup times or need to deploy to an environment without a JVM, you can build a native image.
+
+=== Build using Docker
+
+. Build a Docker image with Maven:
++
+[source, shell]
+----
+$ mvn -Pnative spring-boot:build-image
+----
++
+or with Gradle:
++
+[source, shell]
+----
+$ gradle bootBuildImage
+----
++
+. Start the built Docker image using `docker run`:
++
+[source, shell]
+----
+$ docker run --rm -p 8080:8080 docker.io/library/timefold-solver-spring-boot-school-timetabling-quickstart:1.0-SNAPSHOT
+----
++
+. Visit http://localhost:8080 in your browser.
+
+. Click on the *Solve* button.
+
+=== Build using locally installed GraalVM
+
+. Build it with Maven:
++
+[source, shell]
+----
+$ mvn -Pnative native:compile
+----
++
+or with Gradle:
++
+[source, shell]
+----
+$ gradle nativeCompile
+----
+
+. Run the Maven output:
++
+[source, shell]
+----
+$ ./target/timefold-solver-spring-boot-school-timetabling-quickstart
+----
++
+or the Gradle output:
++
+[source, shell]
+----
+$ ./build/native/nativeCompile/java-spring-boot
+----
++
+[NOTE]
+====
+To run it on port 8081 instead, add `-Dserver.port=8081`.
+====
+
+. Visit http://localhost:8080 in your browser.
+
+. Click on the *Solve* button.
+
 == More information
 
 Visit https://timefold.ai[timefold.ai].

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "org.springframework.boot" version "3.2.2"
     id "io.spring.dependency-management" version "1.1.4"
+    id 'org.graalvm.buildtools.native' version '0.9.28'
     id "java"
 }
 
@@ -39,7 +40,10 @@ dependencies {
     testImplementation "org.awaitility:awaitility"
 
     // UI
-    runtimeOnly "org.webjars:webjars-locator:0.50"
+    // No webjar locator; incompatible in native mode;
+    // see https://github.com/spring-projects/spring-framework/issues/27619
+    // and https://github.com/webjars/webjars-locator-core/issues/96
+    // runtimeOnly "org.webjars:webjars-locator:0.50"
     runtimeOnly "ai.timefold.solver:timefold-solver-webui"
     runtimeOnly "org.webjars:bootstrap:5.2.3"
     runtimeOnly "org.webjars:jquery:3.6.4"
@@ -53,4 +57,9 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
     }
+}
+
+// optimizedLaunch disables the C2 compiler, which has a massive performance impact
+tasks.named("bootRun") {
+    optimizedLaunch = false
 }

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -2,17 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <!-- Spring version must be 3.2.1;
-       Spring version 3.2.2 has a bug that makes native fail to compile
-       (see https://github.com/spring-projects/spring-boot/issues/39277)
-       and Spring version 3.1.x has a conflicting version of an apache-commons
-       library we used.
-  -->
   <!-- Use spring boot parent to use its native profile -->
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </parent>
 
   <groupId>org.acme</groupId>
@@ -24,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
-    <version.org.springframework.boot>3.2.1</version.org.springframework.boot>
+    <version.org.springframework.boot>3.2.2</version.org.springframework.boot>
 
     <version.compiler.plugin>3.12.1</version.compiler.plugin>
     <version.surefire.plugin>3.2.5</version.surefire.plugin>
@@ -152,6 +146,10 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <!-- optimizedLaunch disables the C2 compiler, which has a massive performance impact -->
+          <optimizedLaunch>false</optimizedLaunch>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.graalvm.buildtools</groupId>

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -2,6 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <!-- Spring version must be 3.2.1;
+       Spring version 3.2.2 has a bug that makes native fail to compile
+       (see https://github.com/spring-projects/spring-boot/issues/39277)
+       and Spring version 3.1.x has a conflicting version of an apache-commons
+       library we used.
+  -->
+  <!-- Use spring boot parent to use its native profile -->
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.1</version>
+  </parent>
 
   <groupId>org.acme</groupId>
   <artifactId>timefold-solver-spring-boot-school-timetabling-quickstart</artifactId>
@@ -12,7 +24,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
-    <version.org.springframework.boot>3.2.2</version.org.springframework.boot>
+    <version.org.springframework.boot>3.2.1</version.org.springframework.boot>
 
     <version.compiler.plugin>3.12.1</version.compiler.plugin>
     <version.surefire.plugin>3.2.5</version.surefire.plugin>
@@ -83,12 +95,10 @@
     </dependency>
 
     <!-- UI -->
-    <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>webjars-locator</artifactId>
-      <version>0.50</version>
-      <scope>runtime</scope>
-    </dependency>
+    <!-- No webjar locator; incompatible in native mode;
+         see https://github.com/spring-projects/spring-framework/issues/27619
+         and https://github.com/webjars/webjars-locator-core/issues/96
+     -->
     <dependency>
       <groupId>ai.timefold.solver</groupId>
       <artifactId>timefold-solver-webui</artifactId>
@@ -142,6 +152,10 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/technology/java-spring-boot/src/main/resources/static/index.html
+++ b/technology/java-spring-boot/src/main/resources/static/index.html
@@ -3,9 +3,10 @@
   <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <title>School timetabling - Timefold Spring Boot</title>
-  <link rel="stylesheet" href="/webjars/bootstrap/css/bootstrap.min.css"/>
-  <link rel="stylesheet" href="/webjars/font-awesome/css/all.css"/>
-  <link rel="stylesheet" href="/webjars/timefold/css/timefold-webui.css"/>
+  <!-- Use versioned web jars since native mode do not support web jar locator -->
+  <link rel="stylesheet" href="/webjars/bootstrap/5.2.3/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="/webjars/font-awesome/5.15.1/css/all.css" />
+  <link rel="stylesheet" href="/webjars/timefold/css/timefold-webui.css" />
   <link rel="icon" href="/webjars/timefold/img/timefold-favicon.svg" type="image/svg+xml">
 </head>
 <body>
@@ -145,10 +146,10 @@
   </div>
 </div>
 
-
-<script src="/webjars/bootstrap/js/bootstrap.bundle.min.js"></script>
-<script src="/webjars/jquery/jquery.min.js"></script>
-<script src="/webjars/js-joda/dist/js-joda.min.js"></script>
+<!-- Use versioned web jars since native mode do not support web jar locator -->
+<script src="/webjars/jquery/3.6.4/jquery.min.js"></script>
+<script src="/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
+<script src="/webjars/js-joda/1.11.0/dist/js-joda.min.js"></script>
 <script src="/webjars/timefold/js/timefold-webui.js"></script>
 <script src="/app.js"></script>
 </body>


### PR DESCRIPTION
## Description of the change

Modifications required for Spring Boot Native image to work.
Requires https://github.com/TimefoldAI/timefold-solver/pull/609

Solving, terminate solving, and score explanations works in native mode. Solving is slow due to the GraalVM handling of record classes (see https://github.com/TimefoldAI/timefold-solver/pull/540 ; waiting for a new GraalVM release with the issue fixed).

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [ ] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.