### PR TITLE
chore: Score analysis collapse, replace arrow with chevron icon

### DIFF
--- a/technology/java-spring-boot/src/main/resources/static/app.js
+++ b/technology/java-spring-boot/src/main/resources/static/app.js
@@ -299,13 +299,13 @@ function analyze() {
           matchesRow.append($(`<td/>`).attr('colspan', '6').append(matchesListGroup));
           analysisTBody.append(matchesRow);
 
-          row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + index + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-arrow-down')).click(e => {
+          row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + index + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-chevron-down')).click(e => {
             matchesRow.collapse('toggle');
             let target = $(e.target);
-            if (target.hasClass('fa-arrow-down')) {
-              target.removeClass('fa-arrow-down').addClass('fa-arrow-up');
+            if (target.hasClass('fa-chevron-down')) {
+              target.removeClass('fa-chevron-down').addClass('fa-chevron-up');
             } else {
-              target.removeClass('fa-arrow-up').addClass('fa-arrow-down');
+              target.removeClass('fa-chevron-up').addClass('fa-chevron-down');
             }
           })));
         } else {

--- a/technology/kotlin-quarkus/src/main/resources/META-INF/resources/app.js
+++ b/technology/kotlin-quarkus/src/main/resources/META-INF/resources/app.js
@@ -299,13 +299,13 @@ function analyze() {
           matchesRow.append($(`<td/>`).attr('colspan', '6').append(matchesListGroup));
           analysisTBody.append(matchesRow);
 
-          row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + index + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-arrow-down')).click(e => {
+          row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + index + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-chevron-down')).click(e => {
             matchesRow.collapse('toggle');
             let target = $(e.target);
-            if (target.hasClass('fa-arrow-down')) {
-              target.removeClass('fa-arrow-down').addClass('fa-arrow-up');
+            if (target.hasClass('fa-chevron-down')) {
+              target.removeClass('fa-chevron-down').addClass('fa-chevron-up');
             } else {
-              target.removeClass('fa-arrow-up').addClass('fa-arrow-down');
+              target.removeClass('fa-chevron-up').addClass('fa-chevron-down');
             }
           })));
         } else {

--- a/use-cases/school-timetabling/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/school-timetabling/src/main/resources/META-INF/resources/app.js
@@ -299,13 +299,13 @@ function analyze() {
           matchesRow.append($(`<td/>`).attr('colspan', '6').append(matchesListGroup));
           analysisTBody.append(matchesRow);
 
-          row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + index + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-arrow-down')).click(e => {
+          row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + index + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-chevron-down')).click(e => {
             matchesRow.collapse('toggle');
             let target = $(e.target);
-            if (target.hasClass('fa-arrow-down')) {
-              target.removeClass('fa-arrow-down').addClass('fa-arrow-up');
+            if (target.hasClass('fa-chevron-down')) {
+              target.removeClass('fa-chevron-down').addClass('fa-chevron-up');
             } else {
-              target.removeClass('fa-arrow-up').addClass('fa-arrow-down');
+              target.removeClass('fa-chevron-up').addClass('fa-chevron-down');
             }
           })));
         } else {

--- a/use-cases/vehicle-routing/src/main/resources/META-INF/resources/recommended-fit.js
+++ b/use-cases/vehicle-routing/src/main/resources/META-INF/resources/recommended-fit.js
@@ -126,10 +126,10 @@ function requestRecommendations(visitId, solution, endpointPath) {
                 $(`#row${index2}Button${index}`).click(e => {
                     $(`#row${index2}Collapse${index}`).collapse('toggle');
                     let target = $(e.target);
-                    if (target.hasClass('fa-arrow-down')) {
-                        target.removeClass('fa-arrow-down').addClass('fa-arrow-up');
+                    if (target.hasClass('fa-chevron-down')) {
+                        target.removeClass('fa-chevron-down').addClass('fa-chevron-up');
                     } else {
-                        target.removeClass('fa-arrow-up').addClass('fa-arrow-down');
+                        target.removeClass('fa-chevron-up').addClass('fa-chevron-down');
                     }
                 });
             });

--- a/use-cases/vehicle-routing/src/main/resources/META-INF/resources/score-analysis.js
+++ b/use-cases/vehicle-routing/src/main/resources/META-INF/resources/score-analysis.js
@@ -113,16 +113,16 @@ function visualizeConstraintMatches(analysisTBody, row, constraintIndex, matches
     analysisTBody.append(matchesRow);
 
     if (recommendation) {
-        row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('id', "row" + constraintIndex + "Button" + recommendationIndex).attr('href', "#row" + constraintIndex + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-arrow-down'))));
+        row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('id', "row" + constraintIndex + "Button" + recommendationIndex).attr('href', "#row" + constraintIndex + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-chevron-down'))));
     } else {
-        row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + constraintIndex + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-arrow-down')).click(function (e) {
+        row.append($(`<td/>`).append($(`<a/>`).attr("data-toggle", "collapse").attr('href', "#row" + constraintIndex + "Collapse").append($(`<span/>`).addClass('fas').addClass('fa-chevron-down')).click(function (e) {
             console.log('clicou', e)
             matchesRow.collapse('toggle');
             let target = $(e.target);
-            if (target.hasClass('fa-arrow-down')) {
-                target.removeClass('fa-arrow-down').addClass('fa-arrow-up');
+            if (target.hasClass('fa-chevron-down')) {
+                target.removeClass('fa-chevron-down').addClass('fa-chevron-up');
             } else {
-                target.removeClass('fa-arrow-up').addClass('fa-arrow-down');
+                target.removeClass('fa-chevron-up').addClass('fa-chevron-down');
             }
         })));
     }


### PR DESCRIPTION
Collapse UI's typically use chevrons.
Arrows are typically used for priority (major/minor), etc

After changes:

![image](https://github.com/TimefoldAI/timefold-quickstarts/assets/176880/8636624c-ad4a-4232-8a30-7ce5cca60e5c)
