### PR TITLE
fix: workaround for shadwvariables variable listeners not called in order

### DIFF
--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/solver/StartDateTimeUpdatingVariableListener.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/solver/StartDateTimeUpdatingVariableListener.java
@@ -66,7 +66,7 @@ public class StartDateTimeUpdatingVariableListener implements VariableListener<P
             startProductionDateTime = line.getStartDateTime();
         } else {
             startCleaningDateTime = previousJob.getEndDateTime();
-            startProductionDateTime = startCleaningDateTime.plus(job.getProduct().getCleanupDuration(previousJob.getProduct()));
+            startProductionDateTime = startCleaningDateTime == null ? null : startCleaningDateTime.plus(job.getProduct().getCleanupDuration(previousJob.getProduct()));
         }
         // An equal startCleaningDateTime does not guarantee an equal startProductionDateTime
         for (Job shadowJob = job;
@@ -90,7 +90,7 @@ public class StartDateTimeUpdatingVariableListener implements VariableListener<P
                 startProductionDateTime = null;
             } else {
                 startCleaningDateTime = endDateTime;
-                startProductionDateTime = startCleaningDateTime.plus(shadowJob.getProduct().getCleanupDuration(previousJob.getProduct()));
+                startProductionDateTime = startProductionDateTime == null ? null : startCleaningDateTime.plus(shadowJob.getProduct().getCleanupDuration(previousJob.getProduct()));
                 if (startProductionDateTime.isBefore(shadowJob.getReadyDateTime())) {
                     startProductionDateTime = shadowJob.getReadyDateTime();
                 }


### PR DESCRIPTION
This resolves https://github.com/TimefoldAI/timefold-quickstarts/issues/315

## Description of the change

> Description here

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [ ] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.