### PR TITLE
fix: workaround for shadwvariables variable listeners not called in order

### DIFF
--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Job.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Job.java
@@ -51,7 +51,7 @@ public class Job {
     @PiggybackShadowVariable(shadowVariableName = "startCleaningDateTime")
     private LocalDateTime endDateTime;
 
-    // No-arg constructor required for OptaPlanner and Jackson
+    // No-arg constructor required for Timefold
     public Job() {
     }
 

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Line.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Line.java
@@ -22,7 +22,7 @@ public class Line {
     @PlanningListVariable
     private List<Job> jobs;
 
-    // No-arg constructor required for OptaPlanner and Jackson
+    // No-arg constructor required for Timefold
     public Line() {
     }
 

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/PackagingSchedule.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/PackagingSchedule.java
@@ -30,10 +30,10 @@ public class PackagingSchedule {
     @PlanningScore
     private HardMediumSoftLongScore score;
 
-    // Ignored by OptaPlanner, used by the UI to display solve or stop solving button
+    // Ignored by Timefold, used by the UI to display solve or stop solving button
     private SolverStatus solverStatus;
 
-    // No-arg constructor required for OptaPlanner
+    // No-arg constructor required for Timefold
     public PackagingSchedule() {
     }
 

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Product.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/Product.java
@@ -13,7 +13,6 @@ public class Product {
     /** The map key is previous product on assembly line. */
     private Map<Product, Duration> cleaningDurations;
 
-    // No-arg constructor required for OptaPlanner and Jackson
     public Product() {
     }
 

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/solver/StartDateTimeUpdatingVariableListener.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/domain/solver/StartDateTimeUpdatingVariableListener.java
@@ -66,7 +66,7 @@ public class StartDateTimeUpdatingVariableListener implements VariableListener<P
             startProductionDateTime = line.getStartDateTime();
         } else {
             startCleaningDateTime = previousJob.getEndDateTime();
-            startProductionDateTime = startCleaningDateTime.plus(job.getProduct().getCleanupDuration(previousJob.getProduct()));
+            startProductionDateTime = startCleaningDateTime == null ? null : startCleaningDateTime.plus(job.getProduct().getCleanupDuration(previousJob.getProduct()));
         }
         // An equal startCleaningDateTime does not guarantee an equal startProductionDateTime
         for (Job shadowJob = job;

--- a/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/solver/FoodPackagingConstraintProvider.java
+++ b/use-cases/food-packaging/src/main/java/org/acme/foodpackaging/solver/FoodPackagingConstraintProvider.java
@@ -57,7 +57,8 @@ public class FoodPackagingConstraintProvider implements ConstraintProvider {
     // TODO Currently dwarfed by minimizeAndLoadBalanceMakeSpan in the same score level, because that squares
     protected Constraint operatorCleaningConflict(ConstraintFactory factory) {
         return factory.forEach(Job.class)
-                .join(factory.forEach(Job.class),
+                .filter(job ->job.getLine() != null)
+                .join(factory.forEach(Job.class).filter(job ->job.getLine() != null),
                         Joiners.equal(job -> job.getLine().getOperator()),
                         Joiners.overlapping(Job::getStartCleaningDateTime, Job::getStartProductionDateTime),
                         Joiners.lessThan(Job::getId))


### PR DESCRIPTION
## Description of the change

This resolves https://github.com/TimefoldAI/timefold-quickstarts/issues/315 + fixes broken null references when joining jobs

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [ ] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.