### PR TITLE
fix: Round service finish delay to next or equal minute in vehicle routing

### DIFF
--- a/use-cases/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Visit.java
+++ b/use-cases/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Visit.java
@@ -2,6 +2,8 @@ package org.acme.vehiclerouting.domain;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.lookup.PlanningId;
@@ -164,7 +166,16 @@ public class Visit {
         if (arrivalTime == null) {
             return 0;
         }
-        return Duration.between(maxEndTime, arrivalTime.plus(serviceDuration)).toMinutes();
+        return roundDurationToNextOrEqualMinutes(Duration.between(maxEndTime, arrivalTime.plus(serviceDuration)));
+    }
+
+    private static long roundDurationToNextOrEqualMinutes(Duration duration) {
+        var remainder = duration.minus(duration.truncatedTo(ChronoUnit.MINUTES));
+        var minutes = duration.toMinutes();
+        if (remainder.equals(Duration.ZERO)) {
+            return minutes;
+        }
+        return minutes + 1;
     }
 
     @JsonIgnore

--- a/use-cases/vehicle-routing/src/test/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProviderTest.java
+++ b/use-cases/vehicle-routing/src/test/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProviderTest.java
@@ -91,6 +91,7 @@ class VehicleRoutingConstraintProviderTest {
     void serviceFinishedAfterMaxEndTime() {
         LocalDateTime tomorrow_07_00 = LocalDateTime.of(TOMORROW, LocalTime.of(7, 0));
         LocalDateTime tomorrow_08_00 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0));
+        LocalDateTime tomorrow_08_00_01 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0, 1));
         LocalDateTime tomorrow_08_40 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 40));
         LocalDateTime tomorrow_09_00 = LocalDateTime.of(TOMORROW, LocalTime.of(9, 0));
         LocalDateTime tomorrow_10_30 = LocalDateTime.of(TOMORROW, LocalTime.of(10, 30));
@@ -107,6 +108,12 @@ class VehicleRoutingConstraintProviderTest {
         constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::serviceFinishedAfterMaxEndTime)
                 .given(vehicleA, visit1, visit2)
                 .penalizesBy(90 + visit2.getServiceDuration().toMinutes());
+
+        visit2.setArrivalTime(tomorrow_08_00_01);
+
+        constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::serviceFinishedAfterMaxEndTime)
+                .given(vehicleA, visit1, visit2)
+                .penalizesBy(1);
     }
 
     static void connect(Vehicle vehicle, Visit... visits) {


### PR DESCRIPTION
## Description of the change

When service finish delay is positive and less than a minute, a hard constraint match with 0 weight would be generated (since service finish delay was rounded down to zero).

This make service finish delay round up, so a delay of one second would be rounded up to 1 minute, and have a penalty of 1 instead of zero.

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [ ] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.