### PR TITLE
POC on how the enterprise profile would look like

### DIFF
--- a/java/vehicle-routing/README.adoc
+++ b/java/vehicle-routing/README.adoc
@@ -110,6 +110,18 @@ $ ./target/*-runner
 
 . Click on the *Solve* button.
 
+[[enterprise]]
+== Run the application with the Enterprise Edition
+
+For high-scalability use cases, try the paid Enterprise Edition instead:
+
+. Start the application with Maven:
++
+[source,shell]
+----
+$ mvn clean quarkus:dev -Penterprise
+----
+
 == More information
 
 Visit https://timefold.ai[timefold.ai].

--- a/java/vehicle-routing/pom.xml
+++ b/java/vehicle-routing/pom.xml
@@ -221,6 +221,41 @@
         <quarkus.container-image.build>true</quarkus.container-image.build>
       </properties>
     </profile>
+    <profile>
+      <id>enterprise</id>
+      <activation>
+        <property>
+          <name>enterprise</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>timefold-solver-enterprise</id>
+          <name>Timefold Solver Enterprise Edition</name>
+          <url>https://timefold.jfrog.io/artifactory/releases/</url>
+        </repository>
+      </repositories>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>ai.timefold.solver.enterprise</groupId>
+            <artifactId>timefold-solver-enterprise-bom</artifactId>
+            <version>${version.ai.timefold.solver}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>ai.timefold.solver.enterprise</groupId>
+          <artifactId>timefold-solver-enterprise-quarkus</artifactId>
+        </dependency>
+      </dependencies>
+      <properties>
+        <quarkus.profile>enterprise</quarkus.profile>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/java/vehicle-routing/src/main/resources/application.properties
+++ b/java/vehicle-routing/src/main/resources/application.properties
@@ -1,48 +1,44 @@
 ########################
-# General properties
-########################
-# Enable CORS for runQuickstartsFromSource.sh
-quarkus.http.cors=true
-quarkus.http.cors.origins=/http://localhost:.*/
-
-# Allow all origins in dev-mode
-%dev.quarkus.http.cors.origins=/.*/
-
-# Enable Swagger UI also in the native mode
-quarkus.swagger-ui.always-include=true
-
-########################
 # Timefold properties
 ########################
 
 # The solver runs for 30 seconds. To run for 5 minutes use "5m" and for 2 hours use "2h".
 quarkus.timefold.solver.termination.spent-limit=30s
 
-# To change how many solvers to run in parallel
-# timefold.solver-manager.parallel-solver-count=4
-
-# To run increase CPU cores usage per solver
-# quarkus.timefold.solver.move-thread-count=2
-
 # Temporary comment this out to detect bugs in your code (lowers performance)
 # quarkus.timefold.solver.environment-mode=FULL_ASSERT
 
-# Temporary comment this out to return a feasible solution as soon as possible
-# quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
-
-
 # To see what Timefold is doing, turn on DEBUG or TRACE logging.
-quarkus.log.category."ai.timefold.solver".level=INFO
-%test.quarkus.log.category."ai.timefold.solver".level=INFO
+quarkus.log.category."ai.timefold.solver".level=DEBUG
 %prod.quarkus.log.category."ai.timefold.solver".level=INFO
 
-# XML file for power tweaking, defaults to solverConfig.xml (directly under src/main/resources)
-#quarkus.timefold.solver-config-xml=org/acme/vehiclerouting/solver/vehicleRoutingSolverConfig.xml
+# To power tweak the solver configuration, create src/main/resources/solverConfig.xml
+
+########################
+# Timefold Solver Enterprise Edition properties
+########################
+
+# Increase CPU cores usage per solver
+%enterprise.quarkus.timefold.solver.move-thread-count=AUTO
+
+# TODO Enable Nearby Selection
+# TODO %enterprise.quarkus.timefold.solver.nearby-distance-meter-class=...
 
 ########################
 # Test overrides
 ########################
+
 # Effectively disable this termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Avoid verbose logging
+%test.quarkus.log.category."ai.timefold.solver".level=INFO
+
+########################
+# Native build properties
+########################
+
+# Enable Swagger UI also in the native mode
+quarkus.swagger-ui.always-include=true
 


### PR DESCRIPTION
What it does (currently only for vehicle routing)

- Adds a maven profile "enterprise" to add the repo + deps
- Adds a quarkus profile "enterprise" to activate multithreaded solving
- Cleans up the application.properties.
-- Remove the whole CORS stuff that was needed for the showcase which has been removed
-- Remove other stuff that shouldn't be in there.
-- Use DEBUG logging by default like in the other quickstarts.

Requirements to make this a real PR:

- Apply the maven profile and quarkus profile on all quickstarts
- clean up the application.properties
- add it to the readme
- CI work? => finally quickstarts will test enteprise too :)

The SDK work will affect the readme further, but let's get this one merged first.