### PR TITLE
ci: renaming the Python concurrency group name

### DIFF
--- a/.github/workflows/pull_request_python.yml
+++ b/.github/workflows/pull_request_python.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     concurrency:
-      group: pull_request-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}
+      group: pull_request_python-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}-${{ matrix.python-version }}
       cancel-in-progress: true
     runs-on: ${{matrix.os}}
     strategy:


### PR DESCRIPTION
## Description of the change

This pull request changes the name of the Python group concurrency to avoid duplicate names.

https://github.com/TimefoldAI/timefold-quickstarts/actions/runs/9553704007

## Checklist

### Development

- [NA] The changes have been covered with tests, if necessary.
- [NA] You have a green build, with the exception of the flaky tests.
- [NA] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [NA ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [NA] The console messages are validated for all modules affected by your changes.

### Code Review

- [x] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.