### PR TITLE
chore: Temporarily require Python 3.11+ for employee scheduling and school timetabling

### DIFF
--- a/.github/workflows/pull_request_python.yml
+++ b/.github/workflows/pull_request_python.yml
@@ -24,7 +24,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         java-version: [ 17 ] # Only the first supported LTS; already too many jobs here.
-        python-version: ['3.10', '3.11', '3.12']
+        # TODO: Add Python 3.10 once employee scheduling and school timetabling support it
+        python-version: ['3.11', '3.12']
     timeout-minutes: 120
     steps:
       # Clone timefold-solver

--- a/python/employee-scheduling/README.adoc
+++ b/python/employee-scheduling/README.adoc
@@ -11,7 +11,7 @@ image::./python-employee-scheduling-screenshot.png[]
 [[prerequisites]]
 == Prerequisites
 
-. Install https://www.python.org/downloads/[Python 3.10+]
+. Install https://www.python.org/downloads/[Python 3.11+]
 
 . Install JDK 17+, for example with https://sdkman.io[Sdkman]:
 +

--- a/python/employee-scheduling/pyproject.toml
+++ b/python/employee-scheduling/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 [project]
 name = "employee_scheduling"
 version = "1.0.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     'timefold-solver == 999-dev0',
     'fastapi == 0.111.0',

--- a/python/school-timetabling/README.adoc
+++ b/python/school-timetabling/README.adoc
@@ -11,7 +11,7 @@ image::./python-school-timetabling-screenshot.png[]
 [[prerequisites]]
 == Prerequisites
 
-. Install https://www.python.org/downloads/[Python 3.10+]
+. Install https://www.python.org/downloads/[Python 3.11+]
 
 . Install JDK 17+, for example with https://sdkman.io[Sdkman]:
 +

--- a/python/school-timetabling/pyproject.toml
+++ b/python/school-timetabling/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 [project]
 name = "school_timetabling"
 version = "1.0.0"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     'timefold-solver == 999-dev0',
     'fastapi == 0.111.0',


### PR DESCRIPTION
It appears the pydantic models do not get fully translated and cause calls to CPython, causing a major performance degradation during solving.

## Description of the change

> Description here

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [ ] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.