### PR TITLE
fix: data dropdown not working

### DIFF
--- a/java/facility-location/src/main/resources/META-INF/resources/index.html
+++ b/java/facility-location/src/main/resources/META-INF/resources/index.html
@@ -96,7 +96,7 @@
 
 <script src="/webjars/leaflet/leaflet.js"></script>
 <script src="/webjars/jquery/jquery.min.js"></script>
-<script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+<script src="/webjars/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="/webjars/timefold/js/timefold-webui.js"></script>
 <script src="/app.js"></script>
 </body>

--- a/java/food-packaging/src/main/resources/META-INF/resources/index.html
+++ b/java/food-packaging/src/main/resources/META-INF/resources/index.html
@@ -88,7 +88,7 @@
 </div>
 
 <script src="/webjars/jquery/jquery.min.js"></script>
-<script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+<script src="/webjars/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="/webjars/js-joda/dist/js-joda.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/vis-timeline@7.7.2/standalone/umd/vis-timeline-graph2d.min.js"
         integrity="sha256-Jy2+UO7rZ2Dgik50z3XrrNpnc5+2PAx9MhL2CicodME=" crossorigin="anonymous"></script>

--- a/java/order-picking/src/main/resources/META-INF/resources/index.html
+++ b/java/order-picking/src/main/resources/META-INF/resources/index.html
@@ -112,7 +112,7 @@
 </div>
 
 <script src="/webjars/jquery/jquery.min.js"></script>
-<script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+<script src="/webjars/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="/webjars/js-joda/dist/js-joda.min.js"></script>
 <script src="/webjars/timefold/js/timefold-webui.js"></script>
 <script src="/warehouse-api.js"></script>

--- a/java/spring-boot-integration/src/main/resources/static/index.html
+++ b/java/spring-boot-integration/src/main/resources/static/index.html
@@ -148,7 +148,7 @@
 
 <!-- Use versioned web jars since native mode do not support web jar locator -->
 <script src="/webjars/jquery/3.6.4/jquery.min.js"></script>
-<script src="/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
+<script src="/webjars/bootstrap/5.2.3/js/bootstrap.bundle.min.js"></script>
 <script src="/webjars/js-joda/1.11.0/dist/js-joda.min.js"></script>
 <script src="/webjars/timefold/js/timefold-webui.js"></script>
 <script src="/app.js"></script>


### PR DESCRIPTION
## Description of the change

I noticed the dropdown for demo data wasn't working in the hello world (Spring) app. This is due to an incorrect dependency on the plain `bootstrap.min.js` instead of on `bootstrap.bundle.min.js`. The "plain" dependency does not contain the "popper" library required to render the dropdown. 

Only 3 modules were found to use the "plain" one, all the other ones were already using the "bundle" variant. That is why I decided to align all of them on the bundle variant.

Before fix: 
![Before](https://github.com/TimefoldAI/timefold-quickstarts/assets/11362563/02954913-11fa-496b-9950-c9ad68359d26)

After fix:
![After](https://github.com/TimefoldAI/timefold-quickstarts/assets/11362563/a486b78a-75ee-490c-9510-8e69e4b295e4)

## Checklist

### Development

- [x] The changes have been covered with tests, if necessary.
- [x] You have a green build, with the exception of the flaky tests.
- [x] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [x] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [x] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.