### PR TITLE
Python quickstart polishing: filenames etc

### DIFF
--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
@@ -33,12 +33,14 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
-        return new Constraint[]{
+        return new Constraint[] {
+                // Hard constraints
                 requiredSkill(constraintFactory),
                 noOverlappingShifts(constraintFactory),
                 atLeast10HoursBetweenTwoShifts(constraintFactory),
                 oneShiftPerDay(constraintFactory),
                 unavailableEmployee(constraintFactory),
+                // Soft constraints
                 undesiredDayForEmployee(constraintFactory),
                 desiredDayForEmployee(constraintFactory),
         };

--- a/python/employee-scheduling/src/employee_scheduling/__init__.py
+++ b/python/employee-scheduling/src/employee_scheduling/__init__.py
@@ -1,6 +1,6 @@
 import uvicorn
 
-from .routes import app
+from .rest_api import app
 
 
 def main():

--- a/python/employee-scheduling/src/employee_scheduling/constraints.py
+++ b/python/employee-scheduling/src/employee_scheduling/constraints.py
@@ -13,7 +13,7 @@ def get_shift_duration_in_minutes(shift: Shift) -> int:
 
 
 @constraint_provider
-def scheduling_constraints(constraint_factory: ConstraintFactory):
+def define_constraints(constraint_factory: ConstraintFactory):
     return [
         # Hard constraints
         required_skill(constraint_factory),

--- a/python/employee-scheduling/src/employee_scheduling/constraints.py
+++ b/python/employee-scheduling/src/employee_scheduling/constraints.py
@@ -1,5 +1,4 @@
-from timefold.solver.score import (ConstraintFactory, Joiners, constraint_provider,
-                                   HardSoftScore)
+from timefold.solver.score import (constraint_provider, ConstraintFactory, Joiners, HardSoftScore)
 from datetime import datetime, time, timedelta
 
 from .domain import Employee, Shift
@@ -16,11 +15,13 @@ def get_shift_duration_in_minutes(shift: Shift) -> int:
 @constraint_provider
 def scheduling_constraints(constraint_factory: ConstraintFactory):
     return [
+        # Hard constraints
         required_skill(constraint_factory),
         no_overlapping_shifts(constraint_factory),
         at_least_10_hours_between_two_shifts(constraint_factory),
         one_shift_per_day(constraint_factory),
         unavailable_employee(constraint_factory),
+        # Soft constraints
         undesired_day_for_employee(constraint_factory),
         desired_day_for_employee(constraint_factory),
     ]
@@ -107,14 +108,3 @@ def desired_day_for_employee(constraint_factory: ConstraintFactory):
                     lambda shift: get_shift_duration_in_minutes(shift))
             .as_constraint("Desired day for employee")
             )
-
-
-__all__ = ['scheduling_constraints',
-           'required_skill',
-           'no_overlapping_shifts',
-           'at_least_10_hours_between_two_shifts',
-           'one_shift_per_day',
-           'unavailable_employee',
-           'undesired_day_for_employee',
-           'desired_day_for_employee',
-           ]

--- a/python/employee-scheduling/src/employee_scheduling/demo_data.py
+++ b/python/employee-scheduling/src/employee_scheduling/demo_data.py
@@ -4,7 +4,7 @@ from enum import Enum
 from random import Random
 from typing import Generator
 
-from .domain import (EmployeeSchedule, Employee, Shift)
+from .domain import *
 
 
 class DemoData(Enum):
@@ -143,6 +143,3 @@ def generate_shifts_for_timeslot(timeslot_start: datetime, timeslot_end: datetim
             required_skill=required_skill))
 
     return shifts
-
-
-__all__ = ['DemoData', 'generate_demo_data']

--- a/python/employee-scheduling/src/employee_scheduling/domain.py
+++ b/python/employee-scheduling/src/employee_scheduling/domain.py
@@ -2,34 +2,13 @@ from timefold.solver import SolverStatus
 from timefold.solver.domain import *
 from timefold.solver.score import HardSoftScore
 from datetime import datetime, date, timedelta
-from typing import Annotated, Any
-from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, BeforeValidator, ValidationInfo
-from pydantic.alias_generators import to_camel
+from typing import Annotated
+from pydantic import Field
 
-ScoreSerializer = PlainSerializer(lambda score: str(score) if score is not None else None,
-                                  return_type=str | None)
+from .json_serialization import *
 
 
-def validate_score(v: Any, info: ValidationInfo) -> Any:
-    if isinstance(v, HardSoftScore) or v is None:
-        return v
-    if isinstance(v, str):
-        return HardSoftScore.parse(v)
-    raise ValueError('"score" should be a string')
-
-
-ScoreValidator = BeforeValidator(validate_score)
-
-
-class BaseSchema(BaseModel):
-    model_config = ConfigDict(
-        alias_generator=to_camel,
-        populate_by_name=True,
-        from_attributes=True,
-    )
-
-
-class Employee(BaseSchema):
+class Employee(JsonDomainBase):
     name: Annotated[str, PlanningId]
     skills: Annotated[set[str], Field(default_factory=set)]
     unavailable_dates: Annotated[set[date], Field(default_factory=set)]
@@ -38,27 +17,21 @@ class Employee(BaseSchema):
 
 
 @planning_entity
-class Shift(BaseSchema):
+class Shift(JsonDomainBase):
     id: Annotated[str, PlanningId]
-
     start: datetime
     end: datetime
-
     location: str
     required_skill: str
-
     employee: Annotated[Employee | None,
                         PlanningVariable,
                         Field(default=None)]
 
 
 @planning_solution
-class EmployeeSchedule(BaseSchema):
+class EmployeeSchedule(JsonDomainBase):
     employees: Annotated[list[Employee], ProblemFactCollectionProperty, ValueRangeProvider]
     shifts: Annotated[list[Shift], PlanningEntityCollectionProperty]
     score: Annotated[HardSoftScore | None,
-                     PlanningScore,
-                     ScoreSerializer,
-                     ScoreValidator,
-                     Field(default=None)]
+                     PlanningScore, ScoreSerializer, ScoreValidator, Field(default=None)]
     solver_status: Annotated[SolverStatus | None, Field(default=None)]

--- a/python/employee-scheduling/src/employee_scheduling/json_serialization.py
+++ b/python/employee-scheduling/src/employee_scheduling/json_serialization.py
@@ -1,0 +1,29 @@
+from timefold.solver.score import HardSoftScore
+from typing import Annotated, Any
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, BeforeValidator, ValidationInfo
+from pydantic.alias_generators import to_camel
+
+ScoreSerializer = PlainSerializer(lambda score: str(score) if score is not None else None,
+                                  return_type=str | None)
+
+
+def validate_score(v: Any, info: ValidationInfo) -> Any:
+    if isinstance(v, HardSoftScore) or v is None:
+        return v
+    if isinstance(v, str):
+        hard_part, soft_part = v.split('/')
+        hard = int(hard_part.rstrip('hard'))
+        soft = int(soft_part.rstrip('soft'))
+        return HardSoftScore.of(hard, soft)
+    raise ValueError('"score" should be a string')
+
+
+ScoreValidator = BeforeValidator(validate_score)
+
+
+class JsonDomainBase(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        from_attributes=True,
+    )

--- a/python/employee-scheduling/src/employee_scheduling/json_serialization.py
+++ b/python/employee-scheduling/src/employee_scheduling/json_serialization.py
@@ -11,10 +11,7 @@ def validate_score(v: Any, info: ValidationInfo) -> Any:
     if isinstance(v, HardSoftScore) or v is None:
         return v
     if isinstance(v, str):
-        hard_part, soft_part = v.split('/')
-        hard = int(hard_part.rstrip('hard'))
-        soft = int(soft_part.rstrip('soft'))
-        return HardSoftScore.of(hard, soft)
+        return HardSoftScore.parse(v)
     raise ValueError('"score" should be a string')
 
 

--- a/python/employee-scheduling/src/employee_scheduling/rest_api.py
+++ b/python/employee-scheduling/src/employee_scheduling/rest_api.py
@@ -1,27 +1,9 @@
-from timefold.solver import SolverManager, SolverFactory, SolutionManager
-from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
-                                    TerminationConfig, Duration)
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
-from .domain import EmployeeSchedule, Shift
-from .constraints import scheduling_constraints
+from .domain import EmployeeSchedule
 from .demo_data import DemoData, generate_demo_data
-
-
-solver_config = SolverConfig(
-    solution_class=EmployeeSchedule,
-    entity_class_list=[Shift],
-    score_director_factory_config=ScoreDirectorFactoryConfig(
-        constraint_provider_function=scheduling_constraints
-    ),
-    termination_config=TerminationConfig(
-        spent_limit=Duration(seconds=30)
-    )
-)
-
-solver_manager = SolverManager.create(SolverFactory.create(solver_config))
-solution_manager = SolutionManager.create(solver_manager)
+from .solver import solver_manager, solution_manager
 
 app = FastAPI(docs_url='/q/swagger-ui')
 data_sets: dict[str, EmployeeSchedule] = {}

--- a/python/employee-scheduling/src/employee_scheduling/solver.py
+++ b/python/employee-scheduling/src/employee_scheduling/solver.py
@@ -1,0 +1,21 @@
+from timefold.solver import SolverManager, SolverFactory, SolutionManager
+from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
+                                    TerminationConfig, Duration)
+
+from .domain import EmployeeSchedule, Shift
+from .constraints import define_constraints
+
+
+solver_config = SolverConfig(
+    solution_class=EmployeeSchedule,
+    entity_class_list=[Shift],
+    score_director_factory_config=ScoreDirectorFactoryConfig(
+        constraint_provider_function=define_constraints
+    ),
+    termination_config=TerminationConfig(
+        spent_limit=Duration(seconds=30)
+    )
+)
+
+solver_manager = SolverManager.create(SolverFactory.create(solver_config))
+solution_manager = SolutionManager.create(solver_manager)

--- a/python/employee-scheduling/tests/test_constraints.py
+++ b/python/employee-scheduling/tests/test_constraints.py
@@ -1,8 +1,8 @@
+from datetime import date, datetime, time, timedelta
 from timefold.solver.test import ConstraintVerifier
 
 from employee_scheduling.domain import *
 from employee_scheduling.constraints import *
-from datetime import date, datetime, time, timedelta
 
 
 DAY_1 = date(2021, 2, 1)
@@ -11,7 +11,7 @@ DAY_END_TIME = datetime.combine(DAY_1, time(17, 0))
 AFTERNOON_START_TIME = datetime.combine(DAY_1, time(13, 0))
 AFTERNOON_END_TIME = datetime.combine(DAY_1, time(21, 0))
 
-constraint_verifier = ConstraintVerifier.build(scheduling_constraints, EmployeeSchedule, Shift)
+constraint_verifier = ConstraintVerifier.build(define_constraints, EmployeeSchedule, Shift)
 
 
 def test_required_skill():

--- a/python/employee-scheduling/tests/test_constraints.py
+++ b/python/employee-scheduling/tests/test_constraints.py
@@ -21,7 +21,7 @@ def test_required_skill():
            Shift(id="1", start=DAY_START_TIME, end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee))
     .penalizes(1))
     
-    employee = Employee(name="Beth", skills={"Skill"})
+    employee = Employee(name="Beth", skills={"Skill"}, unavailable_dates=set(), undesired_dates=set(), desired_dates=set())
     (constraint_verifier.verify_that(required_skill)
     .given(employee,
            Shift(id="2", start=DAY_START_TIME, end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee))
@@ -146,17 +146,17 @@ def test_undesired_day_for_employee():
     .given(employee1, employee2,
            Shift(id="1", start=DAY_START_TIME, end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee1))
     .penalizes_by(timedelta(hours=8) // timedelta(minutes=1)))
-    
+
     (constraint_verifier.verify_that(undesired_day_for_employee)
     .given(employee1, employee2,
            Shift(id="1", start=DAY_START_TIME - timedelta(days=1), end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee1))
     .penalizes_by(timedelta(hours=32) // timedelta(minutes=1)))
-    
+
     (constraint_verifier.verify_that(undesired_day_for_employee)
     .given(employee1, employee2,
            Shift(id="1", start=DAY_START_TIME + timedelta(days=1), end=DAY_END_TIME + timedelta(days=1), location="Location", required_skill="Skill", employee=employee1))
     .penalizes(0))
-    
+
     (constraint_verifier.verify_that(undesired_day_for_employee)
     .given(employee1, employee2,
            Shift(id="1", start=DAY_START_TIME, end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee2))

--- a/python/employee-scheduling/tests/test_constraints.py
+++ b/python/employee-scheduling/tests/test_constraints.py
@@ -1,5 +1,5 @@
-from datetime import date, datetime, time, timedelta
 from timefold.solver.test import ConstraintVerifier
+from datetime import date, datetime, time, timedelta
 
 from employee_scheduling.domain import *
 from employee_scheduling.constraints import *

--- a/python/employee-scheduling/tests/test_constraints.py
+++ b/python/employee-scheduling/tests/test_constraints.py
@@ -21,7 +21,7 @@ def test_required_skill():
            Shift(id="1", start=DAY_START_TIME, end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee))
     .penalizes(1))
     
-    employee = Employee(name="Beth", skills={"Skill"}, unavailable_dates=set(), undesired_dates=set(), desired_dates=set())
+    employee = Employee(name="Beth", skills={"Skill"})
     (constraint_verifier.verify_that(required_skill)
     .given(employee,
            Shift(id="2", start=DAY_START_TIME, end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee))

--- a/python/employee-scheduling/tests/test_feasible.py
+++ b/python/employee-scheduling/tests/test_feasible.py
@@ -2,8 +2,8 @@ from timefold.solver import SolverFactory
 from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
                                     TerminationConfig, Duration, TerminationCompositionStyle)
 
-from employee_scheduling.domain import EmployeeSchedule, Shift
-from employee_scheduling.constraints import scheduling_constraints
+from employee_scheduling.domain import *
+from employee_scheduling.constraints import define_constraints
 from employee_scheduling.demo_data import generate_demo_data
 
 
@@ -13,7 +13,7 @@ def test_feasible():
             solution_class=EmployeeSchedule,
             entity_class_list=[Shift],
             score_director_factory_config=ScoreDirectorFactoryConfig(
-                constraint_provider_function=scheduling_constraints
+                constraint_provider_function=define_constraints
             ),
             termination_config=TerminationConfig(
                 termination_config_list=[

--- a/python/hello-world/src/hello_world/constraints.py
+++ b/python/hello-world/src/hello_world/constraints.py
@@ -5,7 +5,7 @@ from datetime import time
 from .domain import Lesson
 
 @constraint_provider
-def school_timetabling_constraints(constraint_factory: ConstraintFactory):
+def define_constraints(constraint_factory: ConstraintFactory):
     return [
         # Hard constraints
         room_conflict(constraint_factory),

--- a/python/hello-world/src/hello_world/main.py
+++ b/python/hello-world/src/hello_world/main.py
@@ -7,7 +7,7 @@ import logging
 import argparse
 
 from .domain import Lesson, Timeslot, Room, Timetable
-from .constraints import school_timetabling_constraints
+from .constraints import define_constraints
 
 
 logging.basicConfig(level=logging.INFO)
@@ -27,7 +27,7 @@ def main():
             solution_class=Timetable,
             entity_class_list=[Lesson],
             score_director_factory_config=ScoreDirectorFactoryConfig(
-                constraint_provider_function=school_timetabling_constraints
+                constraint_provider_function=define_constraints
             ),
             termination_config=TerminationConfig(
                 # The solver runs only for 5 seconds on this small dataset.

--- a/python/hello-world/src/hello_world/main.py
+++ b/python/hello-world/src/hello_world/main.py
@@ -6,7 +6,7 @@ from datetime import time
 import logging
 import argparse
 
-from .domain import Lesson, Timeslot, Room, Timetable
+from .domain import *
 from .constraints import define_constraints
 
 

--- a/python/hello-world/tests/test_constraints.py
+++ b/python/hello-world/tests/test_constraints.py
@@ -1,11 +1,8 @@
 from timefold.solver.test import ConstraintVerifier
 from datetime import time
 
-from hello_world.domain import Timetable, Lesson, Room, Timeslot
-from hello_world.constraints import (define_constraints, room_conflict,
-                                     teacher_conflict, student_group_conflict,
-                                     teacher_room_stability, teacher_time_efficiency,
-                                     student_group_subject_variety)
+from hello_world.domain import *
+from hello_world.constraints import *
 
 ROOM1 = Room("Room1")
 ROOM2 = Room("Room2")

--- a/python/hello-world/tests/test_constraints.py
+++ b/python/hello-world/tests/test_constraints.py
@@ -2,7 +2,7 @@ from timefold.solver.test import ConstraintVerifier
 from datetime import time
 
 from hello_world.domain import Timetable, Lesson, Room, Timeslot
-from hello_world.constraints import (school_timetabling_constraints, room_conflict,
+from hello_world.constraints import (define_constraints, room_conflict,
                                      teacher_conflict, student_group_conflict,
                                      teacher_room_stability, teacher_time_efficiency,
                                      student_group_subject_variety)
@@ -14,7 +14,7 @@ TIMESLOT2 = Timeslot("TUESDAY", time(12, 0), time(13, 0))
 TIMESLOT3 = Timeslot("TUESDAY", time(13, 0), time(14, 0))
 TIMESLOT4 = Timeslot("TUESDAY", time(15, 0), time(16, 0))
 
-constraint_verifier = ConstraintVerifier.build(school_timetabling_constraints, Timetable, Lesson)
+constraint_verifier = ConstraintVerifier.build(define_constraints, Timetable, Lesson)
 
 def test_room_conflict():
     first_lesson = Lesson("1", "Subject1", "Teacher1", "Group1", TIMESLOT1, ROOM1)

--- a/python/hello-world/tests/test_feasible.py
+++ b/python/hello-world/tests/test_feasible.py
@@ -3,7 +3,7 @@ from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
                                     TerminationConfig, Duration, TerminationCompositionStyle)
 
 from hello_world.domain import Timetable, Lesson
-from hello_world.constraints import school_timetabling_constraints
+from hello_world.constraints import define_constraints
 from hello_world.main import generate_demo_data, DemoData
 
 
@@ -13,7 +13,7 @@ def test_feasible():
             solution_class=Timetable,
             entity_class_list=[Lesson],
             score_director_factory_config=ScoreDirectorFactoryConfig(
-                constraint_provider_function=school_timetabling_constraints
+                constraint_provider_function=define_constraints
             ),
             termination_config=TerminationConfig(
                 termination_config_list=[

--- a/python/hello-world/tests/test_feasible.py
+++ b/python/hello-world/tests/test_feasible.py
@@ -2,7 +2,7 @@ from timefold.solver import SolverFactory
 from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
                                     TerminationConfig, Duration, TerminationCompositionStyle)
 
-from hello_world.domain import Timetable, Lesson
+from hello_world.domain import *
 from hello_world.constraints import define_constraints
 from hello_world.main import generate_demo_data, DemoData
 

--- a/python/school-timetabling/src/school_timetabling/__init__.py
+++ b/python/school-timetabling/src/school_timetabling/__init__.py
@@ -1,6 +1,6 @@
 import uvicorn
 
-from .routes import app
+from .rest_api import app
 
 
 def main():

--- a/python/school-timetabling/src/school_timetabling/constraints.py
+++ b/python/school-timetabling/src/school_timetabling/constraints.py
@@ -15,7 +15,6 @@ def school_timetabling_constraints(constraint_factory: ConstraintFactory):
         room_conflict(constraint_factory),
         teacher_conflict(constraint_factory),
         student_group_conflict(constraint_factory),
-
         # Soft constraints
         teacher_room_stability(constraint_factory),
         teacher_time_efficiency(constraint_factory),

--- a/python/school-timetabling/src/school_timetabling/constraints.py
+++ b/python/school-timetabling/src/school_timetabling/constraints.py
@@ -9,7 +9,7 @@ from .justifications import (RoomConflictJustification, TeacherConflictJustifica
 
 
 @constraint_provider
-def school_timetabling_constraints(constraint_factory: ConstraintFactory):
+def define_constraints(constraint_factory: ConstraintFactory):
     return [
         # Hard constraints
         room_conflict(constraint_factory),

--- a/python/school-timetabling/src/school_timetabling/constraints.py
+++ b/python/school-timetabling/src/school_timetabling/constraints.py
@@ -2,10 +2,8 @@ from timefold.solver.score import (constraint_provider, HardSoftScore, Joiners,
                                    ConstraintFactory, Constraint)
 from datetime import time
 
-from .domain import Lesson
-from .justifications import (RoomConflictJustification, TeacherConflictJustification,
-                             StudentGroupConflictJustification, TeacherRoomStabilityJustification,
-                             TeacherTimeEfficiencyJustification, StudentGroupSubjectVarietyJustification)
+from .domain import *
+from .score_analysis import *
 
 
 @constraint_provider

--- a/python/school-timetabling/src/school_timetabling/demo_data.py
+++ b/python/school-timetabling/src/school_timetabling/demo_data.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from datetime import time
 
-from .domain import Timetable, Lesson, Room, Timeslot
+from .domain import *
 
 
 class DemoData(Enum):

--- a/python/school-timetabling/src/school_timetabling/json_serialization.py
+++ b/python/school-timetabling/src/school_timetabling/json_serialization.py
@@ -1,0 +1,48 @@
+from timefold.solver.score import HardSoftScore
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, BeforeValidator, PlainValidator, ValidationInfo
+from pydantic.alias_generators import to_camel
+from typing import Annotated, Any
+
+
+def make_list_item_validator(key: str):
+    def validator(v: Any, info: ValidationInfo) -> Any:
+        if v is None:
+            return None
+
+        if not isinstance(v, str) or not info.context:
+            return v
+
+        return info.context.get(key)[v]
+
+    return BeforeValidator(validator)
+
+
+RoomDeserializer = make_list_item_validator('rooms')
+TimeslotDeserializer = make_list_item_validator('timeslots')
+
+IdSerializer = PlainSerializer(lambda item: item.id if item is not None else None,
+                               return_type=str | None)
+ScoreSerializer = PlainSerializer(lambda score: str(score) if score is not None else None,
+                                  return_type=str | None)
+
+
+def validate_score(v: Any, info: ValidationInfo) -> Any:
+    if isinstance(v, HardSoftScore) or v is None:
+        return v
+    if isinstance(v, str):
+        hard_part, soft_part = v.split('/')
+        hard = int(hard_part.rstrip('hard'))
+        soft = int(soft_part.rstrip('soft'))
+        return HardSoftScore.of(hard, soft)
+    raise ValueError('"score" should be a string')
+
+
+ScoreValidator = BeforeValidator(validate_score)
+
+
+class JsonDomainBase(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        from_attributes=True,
+    )

--- a/python/school-timetabling/src/school_timetabling/json_serialization.py
+++ b/python/school-timetabling/src/school_timetabling/json_serialization.py
@@ -30,10 +30,7 @@ def validate_score(v: Any, info: ValidationInfo) -> Any:
     if isinstance(v, HardSoftScore) or v is None:
         return v
     if isinstance(v, str):
-        hard_part, soft_part = v.split('/')
-        hard = int(hard_part.rstrip('hard'))
-        soft = int(soft_part.rstrip('soft'))
-        return HardSoftScore.of(hard, soft)
+        return HardSoftScore.parse(v)
     raise ValueError('"score" should be a string')
 
 

--- a/python/school-timetabling/src/school_timetabling/rest_api.py
+++ b/python/school-timetabling/src/school_timetabling/rest_api.py
@@ -1,28 +1,12 @@
 from fastapi import FastAPI, Depends, Request
 from fastapi.staticfiles import StaticFiles
-from timefold.solver import SolverManager, SolverFactory, SolutionManager
-from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
-                                    TerminationConfig, Duration)
 from typing import Annotated
 
-from .domain import Timetable, Lesson, Room, Timeslot, ConstraintAnalysisDTO, MatchAnalysisDTO
+from .domain import *
+from .score_analysis import *
 from .constraints import define_constraints
 from .demo_data import DemoData, generate_demo_data
-
-
-solver_config = SolverConfig(
-    solution_class=Timetable,
-    entity_class_list=[Lesson],
-    score_director_factory_config=ScoreDirectorFactoryConfig(
-        constraint_provider_function=define_constraints
-    ),
-    termination_config=TerminationConfig(
-        spent_limit=Duration(seconds=30)
-    )
-)
-
-solver_manager = SolverManager.create(SolverFactory.create(solver_config))
-solution_manager = SolutionManager.create(solver_manager)
+from .solver import solver_manager, solution_manager
 
 app = FastAPI(docs_url='/q/swagger-ui')
 data_sets = {}

--- a/python/school-timetabling/src/school_timetabling/routes.py
+++ b/python/school-timetabling/src/school_timetabling/routes.py
@@ -6,7 +6,7 @@ from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
 from typing import Annotated
 
 from .domain import Timetable, Lesson, Room, Timeslot, ConstraintAnalysisDTO, MatchAnalysisDTO
-from .constraints import school_timetabling_constraints
+from .constraints import define_constraints
 from .demo_data import DemoData, generate_demo_data
 
 
@@ -14,7 +14,7 @@ solver_config = SolverConfig(
     solution_class=Timetable,
     entity_class_list=[Lesson],
     score_director_factory_config=ScoreDirectorFactoryConfig(
-        constraint_provider_function=school_timetabling_constraints
+        constraint_provider_function=define_constraints
     ),
     termination_config=TerminationConfig(
         spent_limit=Duration(seconds=30)

--- a/python/school-timetabling/src/school_timetabling/score_analysis.py
+++ b/python/school-timetabling/src/school_timetabling/score_analysis.py
@@ -1,7 +1,8 @@
 from timefold.solver.score import ConstraintJustification
 from dataclasses import dataclass, field
 
-from .domain import Lesson
+from .json_serialization import *
+from .domain import *
 
 
 @dataclass
@@ -89,11 +90,14 @@ class StudentGroupSubjectVarietyJustification(ConstraintJustification):
                             f"and at '{self.lesson_b.timeslot.day_of_week} {self.lesson_b.timeslot.start_time}'")
 
 
-__all__ = [
-    'RoomConflictJustification',
-    'TeacherConflictJustification',
-    'StudentGroupConflictJustification',
-    'TeacherRoomStabilityJustification',
-    'TeacherTimeEfficiencyJustification',
-    'StudentGroupSubjectVarietyJustification',
-]
+class MatchAnalysisDTO(JsonDomainBase):
+    name: str
+    score: Annotated[HardSoftScore, ScoreSerializer]
+    justification: object
+
+
+class ConstraintAnalysisDTO(JsonDomainBase):
+    name: str
+    weight: Annotated[HardSoftScore, ScoreSerializer]
+    matches: list[MatchAnalysisDTO]
+    score: Annotated[HardSoftScore, ScoreSerializer]

--- a/python/school-timetabling/src/school_timetabling/solver.py
+++ b/python/school-timetabling/src/school_timetabling/solver.py
@@ -7,8 +7,8 @@ from .constraints import define_constraints
 
 
 solver_config = SolverConfig(
-    solution_class=EmployeeSchedule,
-    entity_class_list=[Shift],
+    solution_class=Timetable,
+    entity_class_list=[Lesson],
     score_director_factory_config=ScoreDirectorFactoryConfig(
         constraint_provider_function=define_constraints
     ),

--- a/python/school-timetabling/tests/test_constraints.py
+++ b/python/school-timetabling/tests/test_constraints.py
@@ -1,11 +1,8 @@
 from timefold.solver.test import ConstraintVerifier
 from datetime import time
 
-from school_timetabling.domain import Timetable, Lesson, Room, Timeslot
-from school_timetabling.constraints import (school_timetabling_constraints, room_conflict,
-                                            teacher_conflict, student_group_conflict,
-                                            teacher_room_stability, teacher_time_efficiency,
-                                            student_group_subject_variety)
+from school_timetabling.domain import *
+from school_timetabling.constraints import *
 
 
 ROOM1 = Room(id="1", name="Room1")
@@ -16,7 +13,7 @@ TIMESLOT2 = Timeslot(id="2", day_of_week="TUESDAY", start_time=time(12, 0), end_
 TIMESLOT3 = Timeslot(id="3", day_of_week="TUESDAY", start_time=time(13, 0), end_time=time(14, 0))
 TIMESLOT4 = Timeslot(id="4", day_of_week="TUESDAY", start_time=time(15, 0), end_time=time(16, 0))
 
-constraint_verifier = ConstraintVerifier.build(school_timetabling_constraints, Timetable, Lesson)
+constraint_verifier = ConstraintVerifier.build(define_constraints, Timetable, Lesson)
 
 
 def test_room_conflict():

--- a/python/school-timetabling/tests/test_feasible.py
+++ b/python/school-timetabling/tests/test_feasible.py
@@ -1,5 +1,5 @@
 from school_timetabling.routes import app
-from school_timetabling.domain import Timetable, Room, Timeslot
+from school_timetabling.domain import *
 
 from fastapi.testclient import TestClient
 from time import sleep

--- a/python/school-timetabling/tests/test_feasible.py
+++ b/python/school-timetabling/tests/test_feasible.py
@@ -1,4 +1,4 @@
-from school_timetabling.routes import app
+from school_timetabling.rest_api import app
 from school_timetabling.domain import *
 
 from fastapi.testclient import TestClient

--- a/python/vehicle-routing/src/vehicle_routing/__init__.py
+++ b/python/vehicle-routing/src/vehicle_routing/__init__.py
@@ -1,6 +1,6 @@
 import uvicorn
 
-from .routes import app
+from .rest_api import app
 
 
 def main():

--- a/python/vehicle-routing/src/vehicle_routing/constraints.py
+++ b/python/vehicle-routing/src/vehicle_routing/constraints.py
@@ -8,7 +8,7 @@ MINIMIZE_TRAVEL_TIME = "minimizeTravelTime"
 
 
 @constraint_provider
-def vehicle_routing_constraints(factory: ConstraintFactory):
+def define_constraints(factory: ConstraintFactory):
     return [
         vehicle_capacity(factory),
         minimize_travel_time(factory)

--- a/python/vehicle-routing/src/vehicle_routing/constraints.py
+++ b/python/vehicle-routing/src/vehicle_routing/constraints.py
@@ -1,7 +1,7 @@
 from timefold.solver.score import ConstraintFactory, HardSoftScore, constraint_provider
 
-from .domain import Vehicle
-from .justifications import VehicleCapacityJustification, MinimizeTravelTimeJustification
+from .domain import *
+from .score_analysis import *
 
 VEHICLE_CAPACITY = "vehicleCapacity"
 MINIMIZE_TRAVEL_TIME = "minimizeTravelTime"
@@ -10,7 +10,9 @@ MINIMIZE_TRAVEL_TIME = "minimizeTravelTime"
 @constraint_provider
 def define_constraints(factory: ConstraintFactory):
     return [
+        # Hard constraints
         vehicle_capacity(factory),
+        # Soft constraints
         minimize_travel_time(factory)
     ]
 

--- a/python/vehicle-routing/src/vehicle_routing/constraints.py
+++ b/python/vehicle-routing/src/vehicle_routing/constraints.py
@@ -48,6 +48,3 @@ def minimize_travel_time(factory: ConstraintFactory):
                           vehicle.calculate_total_driving_time_seconds()))
         .as_constraint(MINIMIZE_TRAVEL_TIME)
     )
-
-
-__all__ = ['vehicle_routing_constraints', 'vehicle_capacity', 'minimize_travel_time']

--- a/python/vehicle-routing/src/vehicle_routing/demo_data.py
+++ b/python/vehicle-routing/src/vehicle_routing/demo_data.py
@@ -4,7 +4,7 @@ from enum import Enum
 from random import Random
 from dataclasses import dataclass
 
-from .domain import Location, Visit, Vehicle, VehicleRoutePlan
+from .domain import *
 
 
 FIRST_NAMES = ("Amy", "Beth", "Chad", "Dan", "Elsa", "Flo", "Gus", "Hugo", "Ivy", "Jay")

--- a/python/vehicle-routing/src/vehicle_routing/demo_data.py
+++ b/python/vehicle-routing/src/vehicle_routing/demo_data.py
@@ -124,6 +124,3 @@ def generate_demo_data(demo_data_enum: DemoData) -> VehicleRoutePlan:
 
 def tomorrow_at(local_time: time) -> datetime:
     return datetime.combine(date.today(), local_time)
-
-
-__all__ = ['DemoData', 'generate_demo_data']

--- a/python/vehicle-routing/src/vehicle_routing/json_serialization.py
+++ b/python/vehicle-routing/src/vehicle_routing/json_serialization.py
@@ -1,0 +1,68 @@
+from timefold.solver.score import HardSoftScore, ScoreDirector
+
+from typing import Annotated, Optional, Any
+from pydantic import BaseModel, ConfigDict, PlainSerializer, BeforeValidator, Field, ValidationInfo, computed_field
+from pydantic.alias_generators import to_camel
+
+
+class JsonDomainBase(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        from_attributes=True,
+    )
+
+
+def make_id_item_validator(key: str):
+    def validator(v: Any, info: ValidationInfo) -> Any:
+        if v is None:
+            return None
+
+        if not isinstance(v, str) or not info.context:
+            return v
+
+        return info.context.get(key)[v]
+
+    return BeforeValidator(validator)
+
+
+def make_id_list_item_validator(key: str):
+    def validator(v: Any, info: ValidationInfo) -> Any:
+        if v is None:
+            return None
+
+        if isinstance(v, (list, tuple)):
+            out = []
+            for item in v:
+                if not isinstance(v, str) or not info.context:
+                    return v
+                out.append(info.context.get(key)[item])
+            return out
+
+        return v
+
+    return BeforeValidator(validator)
+
+
+LocationSerializer = PlainSerializer(lambda location: [
+    location.latitude,
+    location.longitude,
+], return_type=list[float])
+ScoreSerializer = PlainSerializer(lambda score: str(score), return_type=str)
+IdSerializer = PlainSerializer(lambda item: item.id if item is not None else None, return_type=str | None)
+IdListSerializer = PlainSerializer(lambda items: [item.id for item in items], return_type=list)
+
+VisitListValidator = make_id_list_item_validator('visits')
+VisitValidator = make_id_item_validator('visits')
+VehicleValidator = make_id_item_validator('vehicles')
+
+
+def validate_score(v: Any, info: ValidationInfo) -> Any:
+    if isinstance(v, HardSoftScore) or v is None:
+        return v
+    if isinstance(v, str):
+        return HardSoftScore.parse(v)
+    raise ValueError('"score" should be a string')
+
+
+ScoreValidator = BeforeValidator(validate_score)

--- a/python/vehicle-routing/src/vehicle_routing/rest_api.py
+++ b/python/vehicle-routing/src/vehicle_routing/rest_api.py
@@ -1,32 +1,13 @@
 from fastapi import FastAPI, Depends, Request
 from fastapi.staticfiles import StaticFiles
-
-from timefold.solver import SolverManager, SolverFactory, SolutionManager, set_class_output_directory
-from timefold.solver.config import (SolverConfig, ScoreDirectorFactoryConfig,
-                                    TerminationConfig, Duration)
 from typing import Annotated
-import pathlib
 
-
-from .domain import VehicleRoutePlan, Vehicle, Visit, MatchAnalysisDTO, ConstraintAnalysisDTO
+from .domain import *
+from .score_analysis import *
 from .constraints import define_constraints
 from .demo_data import DemoData, generate_demo_data
+from .solver import solver_manager, solution_manager
 
-set_class_output_directory(pathlib.Path('target'))
-
-solver_config = SolverConfig(
-    solution_class=VehicleRoutePlan,
-    entity_class_list=[Vehicle, Visit],
-    score_director_factory_config=ScoreDirectorFactoryConfig(
-        constraint_provider_function=define_constraints
-    ),
-    termination_config=TerminationConfig(
-        spent_limit=Duration(seconds=30)
-    )
-)
-
-solver_manager = SolverManager.create(solver_config)
-solution_manager = SolutionManager.create(solver_manager)
 
 app = FastAPI(docs_url='/q/swagger-ui')
 data_sets: dict[str, VehicleRoutePlan] = {}

--- a/python/vehicle-routing/src/vehicle_routing/routes.py
+++ b/python/vehicle-routing/src/vehicle_routing/routes.py
@@ -9,7 +9,7 @@ import pathlib
 
 
 from .domain import VehicleRoutePlan, Vehicle, Visit, MatchAnalysisDTO, ConstraintAnalysisDTO
-from .constraints import vehicle_routing_constraints
+from .constraints import define_constraints
 from .demo_data import DemoData, generate_demo_data
 
 set_class_output_directory(pathlib.Path('target'))
@@ -18,7 +18,7 @@ solver_config = SolverConfig(
     solution_class=VehicleRoutePlan,
     entity_class_list=[Vehicle, Visit],
     score_director_factory_config=ScoreDirectorFactoryConfig(
-        constraint_provider_function=vehicle_routing_constraints
+        constraint_provider_function=define_constraints
     ),
     termination_config=TerminationConfig(
         spent_limit=Duration(seconds=30)

--- a/python/vehicle-routing/src/vehicle_routing/score_analysis.py
+++ b/python/vehicle-routing/src/vehicle_routing/score_analysis.py
@@ -1,6 +1,23 @@
 from timefold.solver.score import ConstraintJustification
 from dataclasses import dataclass, field
 
+from .json_serialization import *
+
+
+
+@dataclass
+class MatchAnalysisDTO:
+    name: str
+    score: Annotated[HardSoftScore, ScoreSerializer]
+    justification: object
+
+
+@dataclass
+class ConstraintAnalysisDTO:
+    name: str
+    weight: Annotated[HardSoftScore, ScoreSerializer]
+    matches: list[MatchAnalysisDTO]
+    score: Annotated[HardSoftScore, ScoreSerializer]
 
 @dataclass
 class VehicleCapacityJustification(ConstraintJustification):
@@ -24,9 +41,3 @@ class MinimizeTravelTimeJustification(ConstraintJustification):
         self.description = (f"Vehicle '{self.vehicle_name}' total travel time is "
                             f"{self.total_driving_time_seconds // (60 * 60)} hours "
                             f"{round(self.total_driving_time_seconds / 60)} minutes.")
-
-
-__all__ = [
-    'VehicleCapacityJustification',
-    'MinimizeTravelTimeJustification',
-]

--- a/python/vehicle-routing/src/vehicle_routing/solver.py
+++ b/python/vehicle-routing/src/vehicle_routing/solver.py
@@ -7,8 +7,8 @@ from .constraints import define_constraints
 
 
 solver_config = SolverConfig(
-    solution_class=EmployeeSchedule,
-    entity_class_list=[Shift],
+    solution_class=VehicleRoutePlan,
+    entity_class_list=[Vehicle, Visit],
     score_director_factory_config=ScoreDirectorFactoryConfig(
         constraint_provider_function=define_constraints
     ),
@@ -17,5 +17,5 @@ solver_config = SolverConfig(
     )
 )
 
-solver_manager = SolverManager.create(SolverFactory.create(solver_config))
+solver_manager = SolverManager.create(solver_config)
 solution_manager = SolutionManager.create(solver_manager)

--- a/python/vehicle-routing/tests/test_constraints.py
+++ b/python/vehicle-routing/tests/test_constraints.py
@@ -11,7 +11,7 @@ LOCATION_1 = Location(latitude=0, longitude=0)
 LOCATION_2 = Location(latitude=3, longitude=4)
 LOCATION_3 = Location(latitude=-1, longitude=1)
 
-constraint_verifier = ConstraintVerifier.build(vehicle_routing_constraints, VehicleRoutePlan, Vehicle, Visit)
+constraint_verifier = ConstraintVerifier.build(define_constraints, VehicleRoutePlan, Vehicle, Visit)
 
 
 def test_vehicle_capacity_unpenalized():

--- a/python/vehicle-routing/tests/test_feasible.py
+++ b/python/vehicle-routing/tests/test_feasible.py
@@ -1,4 +1,4 @@
-from vehicle_routing.routes import json_to_vehicle_route_plan, app
+from vehicle_routing.rest_api import json_to_vehicle_route_plan, app
 
 from fastapi.testclient import TestClient
 from time import sleep


### PR DESCRIPTION
- Removed `__all__` because it's unneeded (quickstarts should be as simple as possible but still demoable)
- standarized constraint method on define_constraints, like in Java
- **Users only need to grok domain.py and, constraint.py**. Maybe solver.py and score_analysis.py later on. Everything else is stuff for the UI/REST/JSON so moved that stuff into seperate files (json_serialization.py, ...).
- Used star imports for domain and constraints.