### PR TITLE
fix: penalizing or rewarding constraints with overlapping time for Employee Scheduling

### DIFF
--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
@@ -1,11 +1,18 @@
 package org.acme.employeescheduling.domain;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.lookup.PlanningId;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @PlanningEntity
 public class Shift {
@@ -87,6 +94,41 @@ public class Shift {
 
     public void setEmployee(Employee employee) {
         this.employee = employee;
+    }
+
+    @JsonIgnore
+    public boolean isOverlappingWith(Collection<LocalDate> dates) {
+        return !getOverlappingDatesForShift(dates).isEmpty();
+    }
+
+    @JsonIgnore
+    public int getOverlappingDurationInMinutes(Collection<LocalDate> dates) {
+        List<LocalDate> overlappingDates = getOverlappingDatesForShift(dates);
+        long overlappingDurationInMinutes = 0;
+        for (LocalDate date : overlappingDates) {
+            overlappingDurationInMinutes += getOverlappingDurationForShift(date);
+        }
+        return (int) overlappingDurationInMinutes;
+    }
+
+    private List<LocalDate> getOverlappingDatesForShift(Collection<LocalDate> dates) {
+        return dates.stream()
+                .filter(d -> getOverlappingDurationForShift(d) > 0)
+                .toList();
+    }
+
+    private long getOverlappingDurationForShift(LocalDate date) {
+        LocalDateTime startDateTime = LocalDateTime.of(date, LocalTime.MIN);
+        LocalDateTime endDateTime = LocalDateTime.of(date, LocalTime.MAX);
+        return getOverlappingDurationInMinutes(startDateTime, endDateTime, getStart(), getEnd());
+    }
+
+    private long getOverlappingDurationInMinutes(LocalDateTime firstStartDateTime, LocalDateTime firstEndDateTime,
+            LocalDateTime secondStartDateTime, LocalDateTime secondEndDateTime) {
+        LocalDateTime maxStartTime = firstStartDateTime.isAfter(secondStartDateTime) ? firstStartDateTime : secondStartDateTime;
+        LocalDateTime minEndTime = firstEndDateTime.isBefore(secondEndDateTime) ? firstEndDateTime : secondEndDateTime;
+        long minutes = maxStartTime.until(minEndTime, ChronoUnit.MINUTES);
+        return minutes > 0 ? minutes : 0;
     }
 
     @Override

--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
@@ -96,18 +96,18 @@ public class Shift {
         return getStart().toLocalDate().equals(date) || getEnd().toLocalDate().equals(date);
     }
 
-    public long getOverlappingDurationInMinutes(LocalDate date) {
+    public int getOverlappingDurationInMinutes(LocalDate date) {
         LocalDateTime startDateTime = LocalDateTime.of(date, LocalTime.MIN);
         LocalDateTime endDateTime = LocalDateTime.of(date, LocalTime.MAX);
         return getOverlappingDurationInMinutes(startDateTime, endDateTime, getStart(), getEnd());
     }
 
-    private long getOverlappingDurationInMinutes(LocalDateTime firstStartDateTime, LocalDateTime firstEndDateTime,
+    private int getOverlappingDurationInMinutes(LocalDateTime firstStartDateTime, LocalDateTime firstEndDateTime,
             LocalDateTime secondStartDateTime, LocalDateTime secondEndDateTime) {
         LocalDateTime maxStartTime = firstStartDateTime.isAfter(secondStartDateTime) ? firstStartDateTime : secondStartDateTime;
         LocalDateTime minEndTime = firstEndDateTime.isBefore(secondEndDateTime) ? firstEndDateTime : secondEndDateTime;
         long minutes = maxStartTime.until(minEndTime, ChronoUnit.MINUTES);
-        return minutes > 0 ? minutes : 0;
+        return minutes > 0 ? (int) minutes : 0;
     }
 
     @Override

--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
@@ -92,6 +92,10 @@ public class Shift {
         this.employee = employee;
     }
 
+    public boolean isOverlappingWithDate(LocalDate date) {
+        return getStart().toLocalDate().equals(date) || getEnd().toLocalDate().equals(date);
+    }
+
     public long getOverlappingDurationInMinutes(LocalDate date) {
         LocalDateTime startDateTime = LocalDateTime.of(date, LocalTime.MIN);
         LocalDateTime endDateTime = LocalDateTime.of(date, LocalTime.MAX);

--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
@@ -4,15 +4,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.lookup.PlanningId;
 import ai.timefold.solver.core.api.domain.variable.PlanningVariable;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @PlanningEntity
 public class Shift {
@@ -96,28 +92,7 @@ public class Shift {
         this.employee = employee;
     }
 
-    @JsonIgnore
-    public boolean isOverlappingWith(Collection<LocalDate> dates) {
-        return !getOverlappingDatesForShift(dates).isEmpty();
-    }
-
-    @JsonIgnore
-    public int getOverlappingDurationInMinutes(Collection<LocalDate> dates) {
-        List<LocalDate> overlappingDates = getOverlappingDatesForShift(dates);
-        long overlappingDurationInMinutes = 0;
-        for (LocalDate date : overlappingDates) {
-            overlappingDurationInMinutes += getOverlappingDurationForShift(date);
-        }
-        return (int) overlappingDurationInMinutes;
-    }
-
-    private List<LocalDate> getOverlappingDatesForShift(Collection<LocalDate> dates) {
-        return dates.stream()
-                .filter(d -> getOverlappingDurationForShift(d) > 0)
-                .toList();
-    }
-
-    private long getOverlappingDurationForShift(LocalDate date) {
+    public long getOverlappingDurationInMinutes(LocalDate date) {
         LocalDateTime startDateTime = LocalDateTime.of(date, LocalTime.MIN);
         LocalDateTime endDateTime = LocalDateTime.of(date, LocalTime.MAX);
         return getOverlappingDurationInMinutes(startDateTime, endDateTime, getStart(), getEnd());

--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
@@ -1,6 +1,8 @@
 package org.acme.employeescheduling.solver;
 
 import static ai.timefold.solver.core.api.score.stream.Joiners.equal;
+import static ai.timefold.solver.core.api.score.stream.Joiners.lessThanOrEqual;
+import static ai.timefold.solver.core.api.score.stream.Joiners.overlapping;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -10,7 +12,6 @@ import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
-import ai.timefold.solver.core.api.score.stream.Joiners;
 
 import org.acme.employeescheduling.domain.Employee;
 import org.acme.employeescheduling.domain.Shift;
@@ -53,7 +54,7 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
 
     Constraint noOverlappingShifts(ConstraintFactory constraintFactory) {
         return constraintFactory.forEachUniquePair(Shift.class, equal(Shift::getEmployee),
-                Joiners.overlapping(Shift::getStart, Shift::getEnd))
+                overlapping(Shift::getStart, Shift::getEnd))
                 .penalize(HardSoftScore.ONE_HARD,
                         EmployeeSchedulingConstraintProvider::getMinuteOverlap)
                 .asConstraint("Overlapping shift");
@@ -61,7 +62,7 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
 
     Constraint atLeast10HoursBetweenTwoShifts(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(Shift.class)
-                .join(Shift.class, equal(Shift::getEmployee), Joiners.lessThanOrEqual(Shift::getEnd, Shift::getStart))
+                .join(Shift.class, equal(Shift::getEmployee), lessThanOrEqual(Shift::getEnd, Shift::getStart))
                 .filter((firstShift,
                         secondShift) -> Duration.between(firstShift.getEnd(), secondShift.getStart()).toHours() < 10)
                 .penalize(HardSoftScore.ONE_HARD,

--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
@@ -84,7 +84,8 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
         return constraintFactory.forEach(Shift.class)
                 .join(Employee.class, equal(Shift::getEmployee, Function.identity()))
                 .flattenLast(Employee::getUnavailableDates)
-                .filter((shift, unavailableDate) -> shift.getOverlappingDurationInMinutes(unavailableDate) > 0)
+                .filter((shift, unavailableDate) -> shift.getStart().toLocalDate().equals(unavailableDate)
+                        || shift.getEnd().toLocalDate().equals(unavailableDate))
                 .penalize(HardSoftScore.ONE_HARD,
                         (shift, unavailableDate) -> (int) shift.getOverlappingDurationInMinutes(unavailableDate))
                 .asConstraint("Unavailable employee");
@@ -94,7 +95,8 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
         return constraintFactory.forEach(Shift.class)
                 .join(Employee.class, equal(Shift::getEmployee, Function.identity()))
                 .flattenLast(Employee::getUndesiredDates)
-                .filter((shift, undesiredDate) -> shift.getOverlappingDurationInMinutes(undesiredDate) > 0)
+                .filter((shift, undesiredDate) -> shift.getStart().toLocalDate().equals(undesiredDate)
+                        || shift.getEnd().toLocalDate().equals(undesiredDate))
                 .penalize(HardSoftScore.ONE_SOFT,
                         (shift, undesiredDate) -> (int) shift.getOverlappingDurationInMinutes(undesiredDate))
                 .asConstraint("Undesired day for employee");
@@ -105,7 +107,8 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
         return constraintFactory.forEach(Shift.class)
                 .join(Employee.class, equal(Shift::getEmployee, Function.identity()))
                 .flattenLast(Employee::getDesiredDates)
-                .filter((shift, desiredDate) -> shift.getOverlappingDurationInMinutes(desiredDate) > 0)
+                .filter((shift, desiredDate) -> shift.getStart().toLocalDate().equals(desiredDate)
+                        || shift.getEnd().toLocalDate().equals(desiredDate))
                 .reward(HardSoftScore.ONE_SOFT,
                         (shift, desiredDate) -> (int) shift.getOverlappingDurationInMinutes(desiredDate))
                 .asConstraint("Desired day for employee");

--- a/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
+++ b/java/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
@@ -84,8 +84,7 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
         return constraintFactory.forEach(Shift.class)
                 .join(Employee.class, equal(Shift::getEmployee, Function.identity()))
                 .flattenLast(Employee::getUnavailableDates)
-                .filter((shift, unavailableDate) -> shift.getStart().toLocalDate().equals(unavailableDate)
-                        || shift.getEnd().toLocalDate().equals(unavailableDate))
+                .filter(Shift::isOverlappingWithDate)
                 .penalize(HardSoftScore.ONE_HARD,
                         (shift, unavailableDate) -> (int) shift.getOverlappingDurationInMinutes(unavailableDate))
                 .asConstraint("Unavailable employee");
@@ -95,8 +94,7 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
         return constraintFactory.forEach(Shift.class)
                 .join(Employee.class, equal(Shift::getEmployee, Function.identity()))
                 .flattenLast(Employee::getUndesiredDates)
-                .filter((shift, undesiredDate) -> shift.getStart().toLocalDate().equals(undesiredDate)
-                        || shift.getEnd().toLocalDate().equals(undesiredDate))
+                .filter(Shift::isOverlappingWithDate)
                 .penalize(HardSoftScore.ONE_SOFT,
                         (shift, undesiredDate) -> (int) shift.getOverlappingDurationInMinutes(undesiredDate))
                 .asConstraint("Undesired day for employee");
@@ -107,8 +105,7 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
         return constraintFactory.forEach(Shift.class)
                 .join(Employee.class, equal(Shift::getEmployee, Function.identity()))
                 .flattenLast(Employee::getDesiredDates)
-                .filter((shift, desiredDate) -> shift.getStart().toLocalDate().equals(desiredDate)
-                        || shift.getEnd().toLocalDate().equals(desiredDate))
+                .filter(Shift::isOverlappingWithDate)
                 .reward(HardSoftScore.ONE_SOFT,
                         (shift, desiredDate) -> (int) shift.getOverlappingDurationInMinutes(desiredDate))
                 .asConstraint("Desired day for employee");

--- a/java/employee-scheduling/src/test/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProviderTest.java
+++ b/java/employee-scheduling/src/test/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProviderTest.java
@@ -20,6 +20,7 @@ import io.quarkus.test.junit.QuarkusTest;
 @QuarkusTest
 class EmployeeSchedulingConstraintProviderTest {
     private static final LocalDate DAY_1 = LocalDate.of(2021, 2, 1);
+    private static final LocalDate DAY_3 = LocalDate.of(2021, 2, 3);
 
     private static final LocalDateTime DAY_START_TIME = DAY_1.atTime(LocalTime.of(9, 0));
     private static final LocalDateTime DAY_END_TIME = DAY_1.atTime(LocalTime.of(17, 0));
@@ -129,7 +130,7 @@ class EmployeeSchedulingConstraintProviderTest {
 
     @Test
     void unavailableEmployee() {
-        Employee employee1 = new Employee("Amy", null, Set.of(DAY_1), null, null);
+        Employee employee1 = new Employee("Amy", null, Set.of(DAY_1, DAY_3), null, null);
         Employee employee2 = new Employee("Beth", null, Set.of(), null, null);
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::unavailableEmployee)
                 .given(employee1, employee2,
@@ -138,7 +139,7 @@ class EmployeeSchedulingConstraintProviderTest {
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::unavailableEmployee)
                 .given(employee1, employee2,
                         new Shift("1", DAY_START_TIME.minusDays(1), DAY_END_TIME, "Location", "Skill", employee1))
-                .penalizesBy((int) Duration.ofHours(32).toMinutes());
+                .penalizesBy((int) Duration.ofHours(17).toMinutes());
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::unavailableEmployee)
                 .given(employee1, employee2,
                        new Shift("1", DAY_START_TIME.plusDays(1), DAY_END_TIME.plusDays(1), "Location", "Skill", employee1))
@@ -151,7 +152,7 @@ class EmployeeSchedulingConstraintProviderTest {
 
     @Test
     void undesiredDayForEmployee() {
-        Employee employee1 = new Employee("Amy", null, null, Set.of(DAY_1), null);
+        Employee employee1 = new Employee("Amy", null, null, Set.of(DAY_1, DAY_3), null);
         Employee employee2 = new Employee("Beth", null, null, Set.of(), null);
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::undesiredDayForEmployee)
                 .given(employee1, employee2,
@@ -160,7 +161,7 @@ class EmployeeSchedulingConstraintProviderTest {
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::undesiredDayForEmployee)
                 .given(employee1, employee2,
                         new Shift("1", DAY_START_TIME.minusDays(1), DAY_END_TIME, "Location", "Skill", employee1))
-                .penalizesBy((int) Duration.ofHours(32).toMinutes());
+                .penalizesBy((int) Duration.ofHours(17).toMinutes());
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::undesiredDayForEmployee)
                 .given(employee1, employee2,
                        new Shift("1", DAY_START_TIME.plusDays(1), DAY_END_TIME.plusDays(1), "Location", "Skill", employee1))
@@ -173,7 +174,7 @@ class EmployeeSchedulingConstraintProviderTest {
 
     @Test
     void desiredDayForEmployee() {
-        Employee employee1 = new Employee("Amy", null, null, null, Set.of(DAY_1));
+        Employee employee1 = new Employee("Amy", null, null, null, Set.of(DAY_1, DAY_3));
         Employee employee2 = new Employee("Beth", null, null, null, Set.of());
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::desiredDayForEmployee)
             .given(employee1, employee2,
@@ -182,7 +183,7 @@ class EmployeeSchedulingConstraintProviderTest {
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::desiredDayForEmployee)
             .given(employee1, employee2,
                 new Shift("1", DAY_START_TIME.minusDays(1), DAY_END_TIME, "Location", "Skill", employee1))
-            .rewardsWith((int) Duration.ofHours(32).toMinutes());
+            .rewardsWith((int) Duration.ofHours(17).toMinutes());
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::desiredDayForEmployee)
             .given(employee1, employee2,
                 new Shift("1", DAY_START_TIME.plusDays(1), DAY_END_TIME.plusDays(1), "Location", "Skill", employee1))

--- a/java/employee-scheduling/src/test/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProviderTest.java
+++ b/java/employee-scheduling/src/test/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProviderTest.java
@@ -113,6 +113,11 @@ class EmployeeSchedulingConstraintProviderTest {
                 .penalizesBy(600);
         constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::atLeast10HoursBetweenTwoShifts)
                 .given(employee1, employee2,
+                        new Shift("1", DAY_END_TIME, DAY_START_TIME.plusDays(1), "Location", "Skill", employee1),
+                        new Shift("2", DAY_START_TIME, DAY_END_TIME, "Location 2", "Skill", employee1))
+                .penalizesBy(600);
+        constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::atLeast10HoursBetweenTwoShifts)
+                .given(employee1, employee2,
                        new Shift("1", DAY_START_TIME, DAY_END_TIME, "Location", "Skill", employee1),
                        new Shift("2", DAY_END_TIME.plusHours(10), DAY_START_TIME.plusDays(1), "Location 2", "Skill", employee1))
                 .penalizes(0);

--- a/python/employee-scheduling/src/employee_scheduling/constraints.py
+++ b/python/employee-scheduling/src/employee_scheduling/constraints.py
@@ -88,7 +88,7 @@ def unavailable_employee(constraint_factory: ConstraintFactory):
             .join(Employee, Joiners.equal(lambda shift: shift.employee, lambda employee: employee))
             .flatten_last(lambda employee: employee.unavailable_dates)
             .filter(
-        lambda shift, unavailable_date: get_shift_overlapping_duration_in_minutes(shift, unavailable_date) > 0)
+        lambda shift, unavailable_date: shift.start.date() == unavailable_date or shift.end.date() == unavailable_date)
             .penalize(HardSoftScore.ONE_HARD,
                       lambda shift, unavailable_date: get_shift_overlapping_duration_in_minutes(shift,
                                                                                                 unavailable_date))
@@ -100,7 +100,8 @@ def undesired_day_for_employee(constraint_factory: ConstraintFactory):
     return (constraint_factory.for_each(Shift)
             .join(Employee, Joiners.equal(lambda shift: shift.employee, lambda employee: employee))
             .flatten_last(lambda employee: employee.undesired_dates)
-            .filter(lambda shift, undesired_date: get_shift_overlapping_duration_in_minutes(shift, undesired_date) > 0)
+            .filter(
+        lambda shift, undesired_date: shift.start.date() == undesired_date or shift.end.date() == undesired_date)
             .penalize(HardSoftScore.ONE_SOFT,
                       lambda shift, undesired_date: get_shift_overlapping_duration_in_minutes(shift, undesired_date))
             .as_constraint("Undesired day for employee")
@@ -111,7 +112,7 @@ def desired_day_for_employee(constraint_factory: ConstraintFactory):
     return (constraint_factory.for_each(Shift)
             .join(Employee, Joiners.equal(lambda shift: shift.employee, lambda employee: employee))
             .flatten_last(lambda employee: employee.desired_dates)
-            .filter(lambda shift, desired_date: get_shift_overlapping_duration_in_minutes(shift, desired_date) > 0)
+            .filter(lambda shift, desired_date: shift.start.date() == desired_date or shift.end.date() == desired_date)
             .reward(HardSoftScore.ONE_SOFT,
                     lambda shift, desired_date: get_shift_overlapping_duration_in_minutes(shift, desired_date))
             .as_constraint("Desired day for employee")

--- a/python/employee-scheduling/tests/test_constraints.py
+++ b/python/employee-scheduling/tests/test_constraints.py
@@ -92,6 +92,12 @@ def test_at_least_10_hours_between_shifts():
            Shift(id="1", start=DAY_START_TIME, end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee1),
            Shift(id="2", start=DAY_END_TIME, end=DAY_START_TIME + timedelta(days=1), location="Location 2", required_skill="Skill", employee=employee1))
     .penalizes_by(600))
+
+    (constraint_verifier.verify_that(at_least_10_hours_between_two_shifts)
+    .given(employee1, employee2,
+           Shift(id="1", start=DAY_END_TIME, end=DAY_START_TIME + timedelta(days=1), location="Location", required_skill="Skill", employee=employee1),
+           Shift(id="2", start=DAY_START_TIME, end=DAY_END_TIME, location="Location 2", required_skill="Skill", employee=employee1))
+    .penalizes_by(600))
     
     (constraint_verifier.verify_that(at_least_10_hours_between_two_shifts)
     .given(employee1, employee2,

--- a/python/employee-scheduling/tests/test_constraints.py
+++ b/python/employee-scheduling/tests/test_constraints.py
@@ -1,11 +1,10 @@
 from timefold.solver.test import ConstraintVerifier
-from datetime import date, datetime, time, timedelta
 
-from employee_scheduling.domain import *
 from employee_scheduling.constraints import *
-
+from employee_scheduling.domain import *
 
 DAY_1 = date(2021, 2, 1)
+DAY_3 = date(2021, 2, 3)
 DAY_START_TIME = datetime.combine(DAY_1, time(9, 0))
 DAY_END_TIME = datetime.combine(DAY_1, time(17, 0))
 AFTERNOON_START_TIME = datetime.combine(DAY_1, time(13, 0))
@@ -114,7 +113,7 @@ def test_at_least_10_hours_between_shifts():
 
 
 def test_unavailable_employee():
-    employee1 = Employee(name="Amy", unavailable_dates={DAY_1})
+    employee1 = Employee(name="Amy", unavailable_dates={DAY_1, DAY_3})
     employee2 = Employee(name="Beth")
 
     (constraint_verifier.verify_that(unavailable_employee)
@@ -125,7 +124,7 @@ def test_unavailable_employee():
     (constraint_verifier.verify_that(unavailable_employee)
     .given(employee1, employee2,
            Shift(id="1", start=DAY_START_TIME - timedelta(days=1), end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee1))
-    .penalizes_by(timedelta(hours=32) // timedelta(minutes=1)))
+    .penalizes_by(timedelta(hours=17) // timedelta(minutes=1)))
     
     (constraint_verifier.verify_that(unavailable_employee)
     .given(employee1, employee2,
@@ -139,7 +138,7 @@ def test_unavailable_employee():
 
 
 def test_undesired_day_for_employee():
-    employee1 = Employee(name="Amy", undesired_dates={DAY_1})
+    employee1 = Employee(name="Amy", undesired_dates={DAY_1, DAY_3})
     employee2 = Employee(name="Beth")
 
     (constraint_verifier.verify_that(undesired_day_for_employee)
@@ -150,7 +149,7 @@ def test_undesired_day_for_employee():
     (constraint_verifier.verify_that(undesired_day_for_employee)
     .given(employee1, employee2,
            Shift(id="1", start=DAY_START_TIME - timedelta(days=1), end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee1))
-    .penalizes_by(timedelta(hours=32) // timedelta(minutes=1)))
+    .penalizes_by(timedelta(hours=17) // timedelta(minutes=1)))
 
     (constraint_verifier.verify_that(undesired_day_for_employee)
     .given(employee1, employee2,
@@ -164,7 +163,7 @@ def test_undesired_day_for_employee():
 
 
 def test_desired_day_for_employee():
-    employee1 = Employee(name="Amy", desired_dates={DAY_1})
+    employee1 = Employee(name="Amy", desired_dates={DAY_1, DAY_3})
     employee2 = Employee(name="Beth")
 
     (constraint_verifier.verify_that(desired_day_for_employee)
@@ -175,7 +174,7 @@ def test_desired_day_for_employee():
     (constraint_verifier.verify_that(desired_day_for_employee)
      .given(employee1, employee2,
             Shift(id="1", start=DAY_START_TIME - timedelta(days=1), end=DAY_END_TIME, location="Location", required_skill="Skill", employee=employee1))
-     .rewards_with(timedelta(hours=32) // timedelta(minutes=1)))
+     .rewards_with(timedelta(hours=17) // timedelta(minutes=1)))
 
     (constraint_verifier.verify_that(desired_day_for_employee)
      .given(employee1, employee2,


### PR DESCRIPTION
## Description of the change

This pull request updates the employee-scheduling module constraints to penalize or reward constraints with overlapping time.

## Java
![Screenshot from 2024-06-20 16-42-35](https://github.com/TimefoldAI/timefold-quickstarts/assets/11961659/a796f1e8-ecf1-46c5-a1eb-43e24f5ff370)

## Python 
![Screenshot from 2024-06-20 19-40-22](https://github.com/TimefoldAI/timefold-quickstarts/assets/11961659/78c9a2ef-120e-4391-803f-6c82307070de)

## Checklist

### Development

- [x] The changes have been covered with tests, if necessary.
- [x] You have a green build, with the exception of the flaky tests.
- [x] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [x] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [x] The console messages are validated for all modules affected by your changes.

### Code Review

- [x] This pull request includes an explanatory title and description.
- [x] The GitHub issue is linked.
- [x] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.