### PR TITLE
docs: Add missing enterprise section to menu links in readme files (#562)

### DIFF
--- a/java/bed-allocation/README.adoc
+++ b/java/bed-allocation/README.adoc
@@ -5,6 +5,7 @@ Assign beds to patient stays to produce a better schedule for hospitals.
 image::./bed-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/conference-scheduling/README.adoc
+++ b/java/conference-scheduling/README.adoc
@@ -5,6 +5,7 @@ Assign conference talks to timeslots and rooms to produce a better schedule for 
 image::./conference-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/employee-scheduling/README.adoc
+++ b/java/employee-scheduling/README.adoc
@@ -5,6 +5,7 @@ Schedule shifts to employees, accounting for employee availability and shift ski
 image::./employee-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/facility-location/README.adoc
+++ b/java/facility-location/README.adoc
@@ -5,6 +5,7 @@ Pick the best geographical locations for new stores, distribution centers, covid
 image::./facility-location-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/flight-crew-scheduling/README.adoc
+++ b/java/flight-crew-scheduling/README.adoc
@@ -5,6 +5,7 @@ Assign crew to flights to produce a better schedule for flight assignments.
 image::./flight-crew-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/food-packaging/README.adoc
+++ b/java/food-packaging/README.adoc
@@ -5,6 +5,7 @@ Schedule food packaging orders to manufacturing lines, to minimize downtime and 
 image::./food-packaging-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/maintenance-scheduling/README.adoc
+++ b/java/maintenance-scheduling/README.adoc
@@ -5,6 +5,7 @@ Schedule maintenance jobs to crews over time to reduce both premature and overdu
 image::./maintenance-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/meeting-scheduling/README.adoc
+++ b/java/meeting-scheduling/README.adoc
@@ -5,6 +5,7 @@ Assign timeslots and rooms for meetings to produce a better schedule.
 image::./meeting-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/order-picking/README.adoc
+++ b/java/order-picking/README.adoc
@@ -5,6 +5,7 @@ Generate an optimal picking plan for completing a set of orders.
 image::./order-picking-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/project-job-scheduling/README.adoc
+++ b/java/project-job-scheduling/README.adoc
@@ -5,6 +5,7 @@ Assign jobs for execution to produce a better schedule for project job allocatio
 image::./project-job-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/school-timetabling/README.adoc
+++ b/java/school-timetabling/README.adoc
@@ -5,6 +5,7 @@ Assign lessons to timeslots and rooms to produce a better schedule for teachers 
 image::./school-timetabling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/sports-league-scheduling/README.adoc
+++ b/java/sports-league-scheduling/README.adoc
@@ -5,6 +5,7 @@ Assign rounds to matches to produce a better schedule for league matches.
 image::./sports-league-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/spring-boot-integration/README.adoc
+++ b/java/spring-boot-integration/README.adoc
@@ -5,6 +5,9 @@ Assign lessons to timeslots and rooms to produce a better schedule for teachers 
 image::./school-timetabling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
+* <<package,Run the packaged application>>
+* <<native,Create a native image>>
 
 == Prerequisites
 

--- a/java/task-assigning/README.adoc
+++ b/java/task-assigning/README.adoc
@@ -5,6 +5,7 @@ Assign employees to tasks to produce a better plan for task assignments.
 image::./task-assigning-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/tournament-scheduling/README.adoc
+++ b/java/tournament-scheduling/README.adoc
@@ -5,6 +5,7 @@ Tournament Scheduling service assigning teams to tournament matches.
 image::./tournament-scheduling-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>

--- a/java/vehicle-routing/README.adoc
+++ b/java/vehicle-routing/README.adoc
@@ -5,6 +5,7 @@ Find the most efficient routes for a fleet of vehicles.
 image::./vehicle-routing-screenshot.png[]
 
 * <<run,Run the application>>
+* <<enterprise,Run the application with Timefold Solver Enterprise Edition>>
 * <<package,Run the packaged application>>
 * <<container,Run the application in a container>>
 * <<native,Run it native>>


### PR DESCRIPTION
## Description of the change

Add the enterprise section to the menu links in the readme files where it is missing (#562).

## Checklist

### Development

~~- [ ] The changes have been covered with tests, if necessary.~~ 
~~- [ ] You have a green build, with the exception of the flaky tests.~~ 
~~- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).~~ 
~~- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).~~ 
~~- [ ] The console messages are validated for all modules affected by your changes.~~ 
--> not relevant for a pure documentation change

### Code Review

- [x] This pull request includes an explanatory title and description.
- [x] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.