### PR TITLE
fix: Consider employee unavailability during flight in flight-crew-scheduling

### DIFF
--- a/java/flight-crew-scheduling/src/main/java/org/acme/flighcrewscheduling/domain/Employee.java
+++ b/java/flight-crew-scheduling/src/main/java/org/acme/flighcrewscheduling/domain/Employee.java
@@ -50,8 +50,16 @@ public class Employee {
     }
 
     @JsonIgnore
-    public boolean isAvailable(LocalDate date) {
-        return unavailableDays == null || !unavailableDays.contains(date);
+    public boolean isAvailable(LocalDate fromDateInclusive, LocalDate toDateInclusive) {
+        if (unavailableDays == null) {
+            return true;
+        }
+        for (var date = fromDateInclusive; !date.isAfter(toDateInclusive); date = date.plusDays(1)) {
+            if (unavailableDays.contains(date)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/java/flight-crew-scheduling/src/main/java/org/acme/flighcrewscheduling/domain/Employee.java
+++ b/java/flight-crew-scheduling/src/main/java/org/acme/flighcrewscheduling/domain/Employee.java
@@ -54,12 +54,9 @@ public class Employee {
         if (unavailableDays == null) {
             return true;
         }
-        for (var date = fromDateInclusive; !date.isAfter(toDateInclusive); date = date.plusDays(1)) {
-            if (unavailableDays.contains(date)) {
-                return false;
-            }
-        }
-        return true;
+        return fromDateInclusive
+                .datesUntil(toDateInclusive.plusDays(1))
+                .noneMatch(unavailableDays::contains);
     }
 
     @Override

--- a/java/flight-crew-scheduling/src/main/java/org/acme/flighcrewscheduling/domain/FlightAssignment.java
+++ b/java/flight-crew-scheduling/src/main/java/org/acme/flighcrewscheduling/domain/FlightAssignment.java
@@ -43,7 +43,7 @@ public class FlightAssignment {
 
     @JsonIgnore
     public boolean isUnavailableEmployee() {
-        return !getEmployee().isAvailable(getFlight().getDepartureUTCDate());
+        return !getEmployee().isAvailable(getFlight().getDepartureUTCDate(), getFlight().getArrivalUTCDateTime().toLocalDate());
     }
 
     @JsonIgnore


### PR DESCRIPTION
## Description of the change

Previously, it was only checked if an employee is available at departure time. However, flights can span multiple days. Thus if an employee is available at departure day, but unavailable on arrivial day, the employee would be incorrectly considered available. Now, all days between (and including) departure and arrival dates are checked.

## Checklist

### Development

- [x] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [x] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [x] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [x] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [x] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.