### PR TITLE
chore: replace deprecated quarkus.package.type property.

### DIFF
--- a/java/bed-allocation/pom.xml
+++ b/java/bed-allocation/pom.xml
@@ -191,7 +191,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/conference-scheduling/pom.xml
+++ b/java/conference-scheduling/pom.xml
@@ -190,7 +190,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/employee-scheduling/pom.xml
+++ b/java/employee-scheduling/pom.xml
@@ -183,7 +183,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
         <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
         <quarkus.profile>native</quarkus.profile>
       </properties>

--- a/java/facility-location/pom.xml
+++ b/java/facility-location/pom.xml
@@ -175,7 +175,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
     <profile>

--- a/java/flight-crew-scheduling/pom.xml
+++ b/java/flight-crew-scheduling/pom.xml
@@ -191,7 +191,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/food-packaging/pom.xml
+++ b/java/food-packaging/pom.xml
@@ -174,7 +174,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
     <profile>

--- a/java/maintenance-scheduling/pom.xml
+++ b/java/maintenance-scheduling/pom.xml
@@ -183,7 +183,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
         <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
         <quarkus.profile>native</quarkus.profile>
       </properties>

--- a/java/meeting-scheduling/pom.xml
+++ b/java/meeting-scheduling/pom.xml
@@ -197,7 +197,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/order-picking/pom.xml
+++ b/java/order-picking/pom.xml
@@ -184,7 +184,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
     <profile>

--- a/java/project-job-scheduling/pom.xml
+++ b/java/project-job-scheduling/pom.xml
@@ -191,7 +191,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/school-timetabling/pom.xml
+++ b/java/school-timetabling/pom.xml
@@ -188,7 +188,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
         <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
         <quarkus.profile>native</quarkus.profile>
       </properties>

--- a/java/sports-league-scheduling/pom.xml
+++ b/java/sports-league-scheduling/pom.xml
@@ -191,7 +191,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/task-assigning/pom.xml
+++ b/java/task-assigning/pom.xml
@@ -197,7 +197,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/tournament-scheduling/pom.xml
+++ b/java/tournament-scheduling/pom.xml
@@ -191,7 +191,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
                 <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
                 <quarkus.profile>native</quarkus.profile>
             </properties>

--- a/java/vehicle-routing/pom.xml
+++ b/java/vehicle-routing/pom.xml
@@ -201,7 +201,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
     </profile>
     <profile>

--- a/kotlin/school-timetabling/pom.xml
+++ b/kotlin/school-timetabling/pom.xml
@@ -240,7 +240,7 @@
         </plugins>
       </build>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
         <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
         <quarkus.profile>native</quarkus.profile>
       </properties>


### PR DESCRIPTION
## Description of the change

The currently used property created warnings because it's deprecated.

> [WARNING] [io.quarkus.deployment.configuration] Configuration property 'quarkus.package.type' has been deprecated and replaced by: [quarkus.package.jar.enabled, quarkus.package.jar.type, quarkus.native.enabled, quarkus.native.sources-only]