### PR TITLE
feat: Generate random job id in Python quickstarts

### DIFF
--- a/python/employee-scheduling/src/employee_scheduling/rest_api.py
+++ b/python/employee-scheduling/src/employee_scheduling/rest_api.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+from uuid import uuid4
 
 from .domain import EmployeeSchedule
 from .demo_data import DemoData, generate_demo_data
@@ -36,10 +37,11 @@ def update_schedule(problem_id: str, schedule: EmployeeSchedule):
 
 @app.post("/schedules")
 async def solve_timetable(schedule: EmployeeSchedule) -> str:
-    data_sets['ID'] = schedule
-    solver_manager.solve_and_listen('ID', schedule,
-                                    lambda solution: update_schedule('ID', solution))
-    return 'ID'
+    job_id = str(uuid4())
+    data_sets[job_id] = schedule
+    solver_manager.solve_and_listen(job_id, schedule,
+                                    lambda solution: update_schedule(job_id, solution))
+    return job_id
 
 
 @app.delete("/schedules/{problem_id}")

--- a/python/school-timetabling/src/school_timetabling/rest_api.py
+++ b/python/school-timetabling/src/school_timetabling/rest_api.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Depends, Request
 from fastapi.staticfiles import StaticFiles
 from typing import Annotated
+from uuid import uuid4
 
 from .domain import *
 from .score_analysis import *
@@ -41,10 +42,11 @@ def update_timetable(problem_id: str, timetable: Timetable):
 
 @app.post("/timetables")
 async def solve_timetable(timetable: Timetable) -> str:
-    data_sets['ID'] = timetable
-    solver_manager.solve_and_listen('ID', timetable,
-                                    lambda solution: update_timetable('ID', solution))
-    return 'ID'
+    job_id = str(uuid4())
+    data_sets[job_id] = timetable
+    solver_manager.solve_and_listen(job_id, timetable,
+                                    lambda solution: update_timetable(job_id, solution))
+    return job_id
 
 
 async def setup_context(request: Request) -> Timetable:

--- a/python/vehicle-routing/src/vehicle_routing/rest_api.py
+++ b/python/vehicle-routing/src/vehicle_routing/rest_api.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends, Request
 from fastapi.staticfiles import StaticFiles
+from uuid import uuid4
 
 from .domain import *
 from .score_analysis import *
@@ -74,10 +75,11 @@ async def setup_context(request: Request) -> VehicleRoutePlan:
 
 @app.post("/route-plans")
 async def solve_route(route: Annotated[VehicleRoutePlan, Depends(setup_context)]) -> str:
-    data_sets['ID'] = route
-    solver_manager.solve_and_listen('ID', route,
-                                    lambda solution: update_route('ID', solution))
-    return 'ID'
+    job_id = str(uuid4())
+    data_sets[job_id] = route
+    solver_manager.solve_and_listen(job_id, route,
+                                    lambda solution: update_route(job_id, solution))
+    return job_id
 
 
 @app.put("/route-plans/analyze")


### PR DESCRIPTION
## Description of the change

Previous the Java Quickstarts used a static id, and the Python quickstarts were a copy of those.
Now the Java Quickstarts use dynamic ids, so the Python quickstarts should too.
Generate a random (UUID4) job id instead of using a static job id.


Fixes #649 

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [x] You have a green build, with the exception of the flaky tests.
- [x] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [x] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [x] The console messages are validated for all modules affected by your changes.

### Code Review

- [x] This pull request includes an explanatory title and description.
- [x] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.