### PR TITLE
ci: upgrade JDK

### DIFF
--- a/.github/workflows/pull_request_maven.yml
+++ b/.github/workflows/pull_request_maven.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macOS-latest]
-        java-version: [ 17, 21, 23 ] #Latest two LTS + latest non-LTS.
+        java-version: [ 17, 21, 24 ] #Latest two LTS + latest non-LTS.
     timeout-minutes: 120
     steps:
       - name: Checkout timefold-quickstarts


### PR DESCRIPTION
Confirmed here: https://github.com/zepfred/timefold-quickstarts/actions/runs/14889273912