### PR TITLE
fix(ci): sanitize PR title input to prevent shell injection

### DIFF
--- a/.github/workflows/pull_request_maven_long_running.yml
+++ b/.github/workflows/pull_request_maven_long_running.yml
@@ -190,10 +190,12 @@ jobs:
         if: ${{ startsWith(github.event.pull_request.title, 'build:') && contains(github.event.pull_request.title, 'release version') && github.event.pull_request.user.login == 'timefold-release' }}
         shell: bash
         working-directory: ./timefold-solver-enterprise
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           git config user.name "Timefold Release Bot"
           git config user.email "release@timefold.ai"
-          NEW_VERSION=`echo '${{ github.event.pull_request.title }}' | grep -oE '[^ ]+$'`
+          NEW_VERSION=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           export NEW_VERSION
           export NEW_VERSION_PYTHON="${NEW_VERSION}"b0
           echo $NEW_VERSION

--- a/.github/workflows/pull_request_maven_long_running.yml
+++ b/.github/workflows/pull_request_maven_long_running.yml
@@ -198,8 +198,8 @@ jobs:
           NEW_VERSION=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           export NEW_VERSION
           export NEW_VERSION_PYTHON="${NEW_VERSION}"b0
-          echo $NEW_VERSION
-          echo $NEW_VERSION_PYTHON
+          echo "$NEW_VERSION"
+          echo "$NEW_VERSION_PYTHON"
           .github/scripts/change_versions.sh
       - name: Quickly build timefold-solver-enterprise
         working-directory: ./timefold-solver-enterprise

--- a/.github/workflows/pull_request_maven_long_running.yml
+++ b/.github/workflows/pull_request_maven_long_running.yml
@@ -191,6 +191,8 @@ jobs:
         shell: bash
         working-directory: ./timefold-solver-enterprise
         env:
+          # PR titles are user-controlled and can contain malicious payloads.
+          # Avoid direct shell interpolation.
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           git config user.name "Timefold Release Bot"


### PR DESCRIPTION
## Description of the change

Improves security in the GitHub Actions workflow by safely extracting the new release version from the PR title. The previous implementation injected the title directly into the shell context, which could lead to command injection if the PR title was crafted maliciously.

Stricter regular expression to match semantic version patterns (e.g., X.Y.Z) and ensures proper quoting of variables to avoid unexpected behavior.

Adds quoting to all variable expansions used in echo statements to align with shell best practices.

Use $(...) notation instead of legacy backticks \`...\`.

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [ ] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.