### PR TITLE
fix: task assignment quickstart overlaps

### DIFF
--- a/java/task-assigning/src/main/java/org/acme/taskassigning/domain/Task.java
+++ b/java/task-assigning/src/main/java/org/acme/taskassigning/domain/Task.java
@@ -31,7 +31,7 @@ public class Task {
     @JsonIgnore
     @PreviousElementShadowVariable(sourceVariableName = "tasks")
     private Task previousTask;
-    @JsonIgnore
+    // Not ignored, because used in UI.
     @ShadowVariable(supplierName = "startTimeSupplier")
     private Integer startTime; // In minutes
 


### PR DESCRIPTION
A field was ignored which is used in the UI.