### PR TITLE
feat: Vehicle Routing: allowsUnassigned

### DIFF
--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Vehicle.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Vehicle.java
@@ -27,7 +27,7 @@ public class Vehicle implements LocationAware {
     private LocalDateTime departureTime;
 
     @JsonIdentityReference(alwaysAsId = true)
-    @PlanningListVariable
+    @PlanningListVariable(allowsUnassignedValues = true)
     private List<Visit> visits;
 
     public Vehicle() {

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/VehicleRoutePlan.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/VehicleRoutePlan.java
@@ -9,7 +9,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningScore;
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
 import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty;
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider;
-import ai.timefold.solver.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import ai.timefold.solver.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import ai.timefold.solver.core.api.solver.SolverStatus;
 
 import org.acme.vehiclerouting.domain.geo.DrivingTimeCalculator;
@@ -52,7 +52,7 @@ public class VehicleRoutePlan {
     private List<Visit> visits;
 
     @PlanningScore
-    private HardSoftLongScore score;
+    private HardMediumSoftLongScore score;
 
     private SolverStatus solverStatus;
 
@@ -62,7 +62,7 @@ public class VehicleRoutePlan {
     public VehicleRoutePlan() {
     }
 
-    public VehicleRoutePlan(String name, HardSoftLongScore score, SolverStatus solverStatus) {
+    public VehicleRoutePlan(String name, HardMediumSoftLongScore score, SolverStatus solverStatus) {
         this.name = name;
         this.score = score;
         this.solverStatus = solverStatus;
@@ -119,11 +119,11 @@ public class VehicleRoutePlan {
         return visits;
     }
 
-    public HardSoftLongScore getScore() {
+    public HardMediumSoftLongScore getScore() {
         return score;
     }
 
-    public void setScore(HardSoftLongScore score) {
+    public void setScore(HardMediumSoftLongScore score) {
         this.score = score;
     }
 

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/rest/VehicleRoutePlanResource.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/rest/VehicleRoutePlanResource.java
@@ -1,7 +1,7 @@
 package org.acme.vehiclerouting.rest;
 
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
-import ai.timefold.solver.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import ai.timefold.solver.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import ai.timefold.solver.core.api.solver.RecommendedAssignment;
 import ai.timefold.solver.core.api.solver.ScoreAnalysisFetchPolicy;
 import ai.timefold.solver.core.api.solver.SolutionManager;
@@ -54,7 +54,7 @@ public class VehicleRoutePlanResource {
 
     private final SolverManager<VehicleRoutePlan, String> solverManager;
 
-    private final SolutionManager<VehicleRoutePlan, HardSoftLongScore> solutionManager;
+    private final SolutionManager<VehicleRoutePlan, HardMediumSoftLongScore> solutionManager;
 
     // TODO: Without any "time to live", the map may eventually grow out of memory.
     private final ConcurrentMap<String, Job> jobIdToJob = new ConcurrentHashMap<>();
@@ -67,7 +67,7 @@ public class VehicleRoutePlanResource {
 
     @Inject
     public VehicleRoutePlanResource(SolverManager<VehicleRoutePlan, String> solverManager,
-                                    SolutionManager<VehicleRoutePlan, HardSoftLongScore> solutionManager) {
+                                    SolutionManager<VehicleRoutePlan, HardMediumSoftLongScore> solutionManager) {
         this.solverManager = solverManager;
         this.solutionManager = solutionManager;
     }
@@ -116,14 +116,20 @@ public class VehicleRoutePlanResource {
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces(MediaType.APPLICATION_JSON)
     @Path("recommendation")
-    public List<RecommendedAssignment<VehicleRecommendation, HardSoftLongScore>> recommendedAssignment(RecommendationRequest request) {
+    public List<RecommendedAssignment<VehicleRecommendation, HardMediumSoftLongScore>> recommendedAssignment(RecommendationRequest request) {
         Visit visit = request.solution().getVisits().stream()
                 .filter(v -> v.getId().equals(request.visitId()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Visit %s not found".formatted(request.visitId())));
-        List<RecommendedAssignment<VehicleRecommendation, HardSoftLongScore>> recommendedAssignments = solutionManager
-                .recommendAssignment(request.solution(), visit, v -> new VehicleRecommendation(v.getVehicle().getId(),
-                        v.getVehicle().getVisits().indexOf(v)));
+        List<RecommendedAssignment<VehicleRecommendation, HardMediumSoftLongScore>> recommendedAssignments = solutionManager
+                .recommendAssignment(request.solution(), visit, v -> {
+                    if(v.getVehicle() != null) {
+                        return new VehicleRecommendation(v.getVehicle().getId(),
+                                v.getVehicle().getVisits().indexOf(v));
+                    } else {
+                        return null;
+                    }
+                });
         if (!recommendedAssignments.isEmpty()) {
             return recommendedAssignments.subList(0, Math.min(MAX_RECOMMENDED_ASSIGNMENT_LIST_SIZE, recommendedAssignments.size()));
         }
@@ -249,7 +255,7 @@ public class VehicleRoutePlanResource {
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces(MediaType.APPLICATION_JSON)
     @Path("analyze")
-    public ScoreAnalysis<HardSoftLongScore> analyze(VehicleRoutePlan problem,
+    public ScoreAnalysis<HardMediumSoftLongScore> analyze(VehicleRoutePlan problem,
                                                     @QueryParam("fetchPolicy") ScoreAnalysisFetchPolicy fetchPolicy) {
         return fetchPolicy == null ? solutionManager.analyze(problem) : solutionManager.analyze(problem, fetchPolicy);
     }

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProvider.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProvider.java
@@ -1,6 +1,6 @@
 package org.acme.vehiclerouting.solver;
 
-import ai.timefold.solver.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import ai.timefold.solver.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
@@ -11,14 +11,21 @@ import org.acme.vehiclerouting.domain.Vehicle;
 public class VehicleRoutingConstraintProvider implements ConstraintProvider {
 
     public static final String VEHICLE_CAPACITY = "vehicleCapacity";
+    public static final String MAXIMIZE_VISITS_ASSIGNED = "maximizeVisitsAssigned";
     public static final String SERVICE_FINISHED_AFTER_MAX_END_TIME = "serviceFinishedAfterMaxEndTime";
     public static final String MINIMIZE_TRAVEL_TIME = "minimizeTravelTime";
 
     @Override
     public Constraint[] defineConstraints(ConstraintFactory factory) {
         return new Constraint[] {
+                // Hard
                 vehicleCapacity(factory),
                 serviceFinishedAfterMaxEndTime(factory),
+
+                // Medium
+                maximizeVisitsAssigned(factory),
+
+                // Soft
                 minimizeTravelTime(factory)
         };
     }
@@ -30,7 +37,7 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
     protected Constraint vehicleCapacity(ConstraintFactory factory) {
         return factory.forEach(Vehicle.class)
                 .filter(vehicle -> vehicle.getTotalDemand() > vehicle.getCapacity())
-                .penalizeLong(HardSoftLongScore.ONE_HARD,
+                .penalizeLong(HardMediumSoftLongScore.ONE_HARD,
                         vehicle -> vehicle.getTotalDemand() - vehicle.getCapacity())
                 .asConstraint(VEHICLE_CAPACITY);
     }
@@ -38,9 +45,20 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
     protected Constraint serviceFinishedAfterMaxEndTime(ConstraintFactory factory) {
         return factory.forEach(Visit.class)
                 .filter(Visit::isServiceFinishedAfterMaxEndTime)
-                .penalizeLong(HardSoftLongScore.ONE_HARD,
+                .penalizeLong(HardMediumSoftLongScore.ONE_HARD,
                         Visit::getServiceFinishedDelayInMinutes)
                 .asConstraint(SERVICE_FINISHED_AFTER_MAX_END_TIME);
+    }
+
+    // ************************************************************************
+    // Medium constraints
+    // ************************************************************************
+
+    protected Constraint maximizeVisitsAssigned(ConstraintFactory factory) {
+        return factory.forEachIncludingUnassigned(Visit.class)
+                .filter(v -> v.getVehicle() == null)
+                .penalizeLong(HardMediumSoftLongScore.ONE_MEDIUM, v-> v.getServiceDuration().toMinutes())
+                .asConstraint(MAXIMIZE_VISITS_ASSIGNED);
     }
 
     // ************************************************************************
@@ -49,7 +67,7 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
 
     protected Constraint minimizeTravelTime(ConstraintFactory factory) {
         return factory.forEach(Vehicle.class)
-                .penalizeLong(HardSoftLongScore.ONE_SOFT,
+                .penalizeLong(HardMediumSoftLongScore.ONE_SOFT,
                         Vehicle::getTotalDrivingTimeSeconds)
                 .asConstraint(MINIMIZE_TRAVEL_TIME);
     }

--- a/java/vehicle-routing/src/main/resources/META-INF/resources/app.js
+++ b/java/vehicle-routing/src/main/resources/META-INF/resources/app.js
@@ -133,7 +133,14 @@ function getHomeLocationMarker(vehicle) {
     if (marker) {
         return marker;
     }
-    marker = L.circleMarker(vehicle.homeLocation, { color: colorByVehicle(vehicle).bg, fillOpacity: 0.8 });
+    const color = colorByVehicle(vehicle);
+    const homeIcon = L.divIcon({
+        html: `<i class="fas fa-home" style="color: ${color.bg}; font-size: 20px; text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;"></i>`,
+        className: 'home-location-icon',
+        iconSize: [20, 20],
+        iconAnchor: [10, 10]
+    });
+    marker = L.marker(vehicle.homeLocation, { icon: homeIcon });
     marker.addTo(homeLocationGroup).bindPopup();
     homeLocationMarkerByIdMap.set(vehicle.id, marker);
     return marker;
@@ -165,8 +172,8 @@ function renderRoutes(solution) {
         vehiclesTable.append(`
       <tr>
         <td>
-          <i class="fas fa-crosshairs" id="crosshairs-${id}"
-            style="background-color: ${color.bg}; display: inline-block; width: 1rem; height: 1rem; text-align: center">
+          <i class="fas fa-home" id="home-${id}"
+            style="color: ${color.bg}; font-size: 1.2rem; display: inline-block; width: 1rem; text-align: center">
           </i>
         </td>
         <td>Vehicle ${id}</td>
@@ -181,7 +188,16 @@ function renderRoutes(solution) {
     });
     // Visits
     solution.visits.forEach(function (visit) {
-        getVisitMarker(visit).setPopupContent(visitPopupContent(visit));
+        const marker = getVisitMarker(visit);
+        marker.setPopupContent(visitPopupContent(visit));
+        if (visit.vehicle != null) {
+            const vehicle = solution.vehicles.find(v => v.id === visit.vehicle);
+            if (vehicle) {
+                marker.setStyle({color: colorByVehicle(vehicle).bg, fillOpacity: 0.8});
+            }
+        } else {
+            marker.setStyle({color: '#999999', fillOpacity: 0.5});
+        }
     });
     // Route
     routeGroup.clearLayers();

--- a/java/vehicle-routing/src/main/resources/META-INF/resources/recommended-fit.js
+++ b/java/vehicle-routing/src/main/resources/META-INF/resources/recommended-fit.js
@@ -103,8 +103,13 @@ function requestRecommendations(visitId, solution, endpointPath) {
             analysisTable.append(analysisTBody);
             visitOptions += "<div class='form-check'>" +
                 `  <input class='form-check-input' type='radio' name='recommendationOptions' id='option${index}' value='option${index}' ${index === 0 ? 'checked=true' : ''}>` +
-                `  <label class='form-check-label' for='option${index}'>` +
-                `    Add <b>${visit.name}</b> to the vehicle <b>${recommendation.proposition.vehicleId}</b> at the position <b> ${recommendation.proposition.index + 1} (${recommendation.scoreDiff.score})</b>${index === 0 ? ' - <b>Best Solution</b>': ''}` +
+                `  <label class='form-check-label' for='option${index}'>` ;
+                    if(recommendation.proposition == null) {
+                        visitOptions += `Leave <b>${visit.name}</b> unassigned`
+                    } else {
+                        visitOptions += `Add <b>${visit.name}</b> to the vehicle <b>${recommendation.proposition?.vehicleId}</b> at the position <b> ${recommendation.proposition?.index + 1}`
+                    }
+            visitOptions += `(${recommendation.scoreDiff.score})</b>${index === 0 ? ' - <b>Best Solution</b>': ''}` +
                 "  </label>" +
                 `  <a id="analyzeRecommendationButton${index}" class="float-justify" href="#" role="button">` +
                 "    <i class='fas fa-chevron-down'></i>" +

--- a/java/vehicle-routing/src/main/resources/application.properties
+++ b/java/vehicle-routing/src/main/resources/application.properties
@@ -12,7 +12,7 @@ quarkus.timefold.solver.termination.spent-limit=30s
 # quarkus.timefold.solver.environment-mode=FULL_ASSERT
 
 # Temporary comment this out to return a feasible solution as soon as possible
-# quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+# quarkus.timefold.solver.termination.best-score-limit=0hard/0medium/*soft
 
 # To see what Timefold is doing, turn on DEBUG or TRACE logging.
 quarkus.log.category."ai.timefold.solver".level=INFO
@@ -44,5 +44,5 @@ quarkus.swagger-ui.always-include=true
 ########################
 # Effectively disable this termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
-%test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+%test.quarkus.timefold.solver.termination.best-score-limit=0hard/0medium/*soft
 

--- a/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/domain/jackson/VRPScoreAnalysisJacksonDeserializer.java
+++ b/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/domain/jackson/VRPScoreAnalysisJacksonDeserializer.java
@@ -1,22 +1,22 @@
 package org.acme.vehiclerouting.domain.jackson;
 
-import ai.timefold.solver.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import ai.timefold.solver.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import ai.timefold.solver.core.api.score.constraint.ConstraintRef;
 import ai.timefold.solver.core.api.score.stream.ConstraintJustification;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.jackson.api.score.analysis.AbstractScoreAnalysisJacksonDeserializer;
 
-public class VRPScoreAnalysisJacksonDeserializer extends AbstractScoreAnalysisJacksonDeserializer<HardSoftLongScore> {
+public class VRPScoreAnalysisJacksonDeserializer extends AbstractScoreAnalysisJacksonDeserializer<HardMediumSoftLongScore> {
 
     @Override
-    protected HardSoftLongScore parseScore(String scoreString) {
-        return HardSoftLongScore.parseScore(scoreString);
+    protected HardMediumSoftLongScore parseScore(String scoreString) {
+        return HardMediumSoftLongScore.parseScore(scoreString);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     protected <ConstraintJustification_ extends ConstraintJustification> ConstraintJustification_ parseConstraintJustification(
-            ConstraintRef constraintRef, String constraintJustificationString, HardSoftLongScore score) {
+            ConstraintRef constraintRef, String constraintJustificationString, HardMediumSoftLongScore score) {
         return (ConstraintJustification_) DefaultConstraintJustification.of(score);
     }
 }

--- a/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProviderTest.java
+++ b/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProviderTest.java
@@ -33,6 +33,11 @@ class VehicleRoutingConstraintProviderTest {
     private static final Location LOCATION_3 = new Location(49.1767533245638, 16.50422914190477);
 
     private static final LocalDate TOMORROW = LocalDate.now().plusDays(1);
+    private static final LocalDateTime TOMORROW_07_00 = LocalDateTime.of(TOMORROW, LocalTime.of(7, 0));
+    private static final LocalDateTime TOMORROW_08_00 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0));
+    private static final LocalDateTime TOMORROW_09_00 = LocalDateTime.of(TOMORROW, LocalTime.of(9, 0));
+    private static final LocalDateTime TOMORROW_10_00 = LocalDateTime.of(TOMORROW, LocalTime.of(10, 0));
+
     @Inject
     ConstraintVerifier<VehicleRoutingConstraintProvider, VehicleRoutePlan> constraintVerifier;
 
@@ -43,11 +48,8 @@ class VehicleRoutingConstraintProviderTest {
 
     @Test
     void vehicleCapacityUnpenalized() {
-        LocalDateTime tomorrow_07_00 = LocalDateTime.of(TOMORROW, LocalTime.of(7, 0));
-        LocalDateTime tomorrow_08_00 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0));
-        LocalDateTime tomorrow_10_00 = LocalDateTime.of(TOMORROW, LocalTime.of(10, 0));
-        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, tomorrow_07_00);
-        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, tomorrow_08_00, tomorrow_10_00, Duration.ofMinutes(30L));
+        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, TOMORROW_07_00);
+        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, TOMORROW_08_00, TOMORROW_10_00, Duration.ofMinutes(30L));
         vehicleA.getVisits().add(visit1);
 
         constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::vehicleCapacity)
@@ -56,14 +58,20 @@ class VehicleRoutingConstraintProviderTest {
     }
 
     @Test
+    void unassignedPenalizedByDuration() {
+        Visit visit = new Visit("2", "John", LOCATION_2, 80, TOMORROW_08_00, TOMORROW_10_00, Duration.ofMinutes(30L));
+
+        constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::maximizeVisitsAssigned)
+                .given(visit)
+                .penalizesBy(30L);
+    }
+
+    @Test
     void vehicleCapacityPenalized() {
-        LocalDateTime tomorrow_07_00 = LocalDateTime.of(TOMORROW, LocalTime.of(7, 0));
-        LocalDateTime tomorrow_08_00 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0));
-        LocalDateTime tomorrow_10_00 = LocalDateTime.of(TOMORROW, LocalTime.of(10, 0));
-        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, tomorrow_07_00);
-        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, tomorrow_08_00, tomorrow_10_00, Duration.ofMinutes(30L));
+        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, TOMORROW_07_00);
+        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, TOMORROW_08_00, TOMORROW_10_00, Duration.ofMinutes(30L));
         vehicleA.getVisits().add(visit1);
-        Visit visit2 = new Visit("3", "Paul", LOCATION_3, 40, tomorrow_08_00, tomorrow_10_00, Duration.ofMinutes(30L));
+        Visit visit2 = new Visit("3", "Paul", LOCATION_3, 40, TOMORROW_08_00, TOMORROW_10_00, Duration.ofMinutes(30L));
         vehicleA.getVisits().add(visit2);
 
         constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::vehicleCapacity)
@@ -73,13 +81,10 @@ class VehicleRoutingConstraintProviderTest {
 
     @Test
     void totalDrivingTime() {
-        LocalDateTime tomorrow_07_00 = LocalDateTime.of(TOMORROW, LocalTime.of(7, 0));
-        LocalDateTime tomorrow_08_00 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0));
-        LocalDateTime tomorrow_10_00 = LocalDateTime.of(TOMORROW, LocalTime.of(10, 0));
-        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, tomorrow_07_00);
-        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, tomorrow_08_00, tomorrow_10_00, Duration.ofMinutes(30L));
+        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, TOMORROW_07_00);
+        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, TOMORROW_08_00, TOMORROW_10_00, Duration.ofMinutes(30L));
         vehicleA.getVisits().add(visit1);
-        Visit visit2 = new Visit("3", "Paul", LOCATION_3, 40, tomorrow_08_00, tomorrow_10_00, Duration.ofMinutes(30L));
+        Visit visit2 = new Visit("3", "Paul", LOCATION_3, 40, TOMORROW_08_00, TOMORROW_10_00, Duration.ofMinutes(30L));
         vehicleA.getVisits().add(visit2);
 
         constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::minimizeTravelTime)
@@ -89,19 +94,16 @@ class VehicleRoutingConstraintProviderTest {
 
     @Test
     void serviceFinishedAfterMaxEndTime() {
-        LocalDateTime tomorrow_07_00 = LocalDateTime.of(TOMORROW, LocalTime.of(7, 0));
-        LocalDateTime tomorrow_08_00 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0));
         LocalDateTime tomorrow_08_00_01 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0, 1));
         LocalDateTime tomorrow_08_40 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 40));
-        LocalDateTime tomorrow_09_00 = LocalDateTime.of(TOMORROW, LocalTime.of(9, 0));
         LocalDateTime tomorrow_10_30 = LocalDateTime.of(TOMORROW, LocalTime.of(10, 30));
         LocalDateTime tomorrow_18_00 = LocalDateTime.of(TOMORROW, LocalTime.of(18, 0));
 
-        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, tomorrow_08_00, tomorrow_18_00, Duration.ofHours(1L));
+        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, TOMORROW_08_00, tomorrow_18_00, Duration.ofHours(1L));
         visit1.setArrivalTime(tomorrow_08_40);
-        Visit visit2 = new Visit("3", "Paul", LOCATION_3, 40, tomorrow_08_00, tomorrow_09_00, Duration.ofHours(1L));
+        Visit visit2 = new Visit("3", "Paul", LOCATION_3, 40, TOMORROW_08_00, TOMORROW_09_00, Duration.ofHours(1L));
         visit2.setArrivalTime(tomorrow_10_30);
-        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, tomorrow_07_00);
+        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, TOMORROW_07_00);
 
         connect(vehicleA, visit1, visit2);
 


### PR DESCRIPTION
## Description of the change

Solves part of #326

Additionally: 
- Make the color of the visits match the assigned vehicle (instead of blue).
- Replace the ugly crosshairs with houses
- Support "unassigned" as a better option in recommendations
<img width="848" height="804" alt="image" src="https://github.com/user-attachments/assets/12955ae7-29e9-468e-8a2c-9ce908d41a55" />
<img width="1178" height="663" alt="image" src="https://github.com/user-attachments/assets/0a908754-6045-4de5-b50a-588b87626679" />


## Checklist

### Development

- [x] The changes have been covered with tests, if necessary.
- [x] You have a green build, with the exception of the flaky tests.
- [x] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [x] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [x] The console messages are validated for all modules affected by your changes.

### Code Review

- [x] This pull request includes an explanatory title and description.
- [x] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.