### PR TITLE
fix: re-add error handling

### DIFF
--- a/java/bed-allocation/src/main/resources/META-INF/resources/app.js
+++ b/java/bed-allocation/src/main/resources/META-INF/resources/app.js
@@ -410,3 +410,46 @@ function compareTimeslots(t1, t2) {
     }
     return diff;
 }
+
+function showSimpleError(title) {
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/conference-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/conference-scheduling/src/main/resources/META-INF/resources/app.js
@@ -543,4 +543,33 @@ function compareTimeslots(t1, t2) {
     return diff;
 }
 
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}
+
 

--- a/java/employee-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/employee-scheduling/src/main/resources/META-INF/resources/app.js
@@ -426,3 +426,32 @@ function stopSolving() {
         showError("Stop solving failed.", xhr);
     });
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/facility-location/src/main/resources/META-INF/resources/app.js
+++ b/java/facility-location/src/main/resources/META-INF/resources/app.js
@@ -300,3 +300,32 @@ stopSolvingButton.click(stopSolving);
 analyzeButton.click(analyze);
 
 updateSolvingStatus();
+
+function showError(title, xhr) {
+  let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+  let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+  let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+  let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+  if (xhr.responseJSON && !serverErrorMessage) {
+    serverErrorMessage = JSON.stringify(xhr.responseJSON);
+    serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+    serverErrorId = `----`;
+  }
+
+  console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+  const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+      .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+      .append($(`<div class="toast-body"/>`)
+          .append($(`<p/>`).text(title))
+          .append($(`<pre/>`)
+              .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+          )
+      );
+  $("#notificationPanel").append(notification);
+  notification.toast({delay: 30000});
+  notification.toast('show');
+}

--- a/java/facility-location/src/main/resources/META-INF/resources/index.html
+++ b/java/facility-location/src/main/resources/META-INF/resources/index.html
@@ -24,6 +24,7 @@
 
 <header class="bg-white shadow">
   <div class="container-fluid">
+    <div id="notificationPanel" style="position: absolute; top: .5rem;"></div>
     <nav class="navbar sticky-top  navbar-expand-lg navbar-light" style="background-color: white; ">
       <a class="navbar-brand" style="width: 200px;overflow: hidden;">
         <img src="https://timefold.ai/uploads/images/Brand-Assets/timefold-solver-logo.png" alt="Timefold Solver logo" width="200px" style="margin-top:-20px;margin-bottom:-20px">

--- a/java/flight-crew-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/flight-crew-scheduling/src/main/resources/META-INF/resources/app.js
@@ -393,3 +393,32 @@ function copyTextToClipboard(id) {
     document.execCommand("copy");
     document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/food-packaging/src/main/resources/META-INF/resources/app.js
+++ b/java/food-packaging/src/main/resources/META-INF/resources/app.js
@@ -324,3 +324,32 @@ function stopSolving() {
     showError("Stop solving failed.", xhr);
   });
 }
+
+function showError(title, xhr) {
+  let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+  let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+  let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+  let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+  if (xhr.responseJSON && !serverErrorMessage) {
+    serverErrorMessage = JSON.stringify(xhr.responseJSON);
+    serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+    serverErrorId = `----`;
+  }
+
+  console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+  const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+      .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+      .append($(`<div class="toast-body"/>`)
+          .append($(`<p/>`).text(title))
+          .append($(`<pre/>`)
+              .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+          )
+      );
+  $("#notificationPanel").append(notification);
+  notification.toast({delay: 30000});
+  notification.toast('show');
+}

--- a/java/maintenance-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/maintenance-scheduling/src/main/resources/META-INF/resources/app.js
@@ -375,3 +375,32 @@ function stopSolving() {
         showError("Stop solving failed.", xhr);
     });
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/meeting-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/meeting-scheduling/src/main/resources/META-INF/resources/app.js
@@ -400,3 +400,32 @@ function copyTextToClipboard(id) {
     document.execCommand("copy");
     document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/order-picking/src/main/resources/META-INF/resources/app.js
+++ b/java/order-picking/src/main/resources/META-INF/resources/app.js
@@ -688,3 +688,32 @@ function setupAjax() {
         };
     });
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/project-job-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/project-job-scheduling/src/main/resources/META-INF/resources/app.js
@@ -422,3 +422,32 @@ function copyTextToClipboard(id) {
     document.execCommand("copy");
     document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/school-timetabling/src/main/resources/META-INF/resources/app.js
+++ b/java/school-timetabling/src/main/resources/META-INF/resources/app.js
@@ -375,3 +375,32 @@ function copyTextToClipboard(id) {
   document.execCommand("copy");
   document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+  let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+  let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+  let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+  let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+  if (xhr.responseJSON && !serverErrorMessage) {
+    serverErrorMessage = JSON.stringify(xhr.responseJSON);
+    serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+    serverErrorId = `----`;
+  }
+
+  console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+  const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+      .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+      .append($(`<div class="toast-body"/>`)
+          .append($(`<p/>`).text(title))
+          .append($(`<pre/>`)
+              .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+          )
+      );
+  $("#notificationPanel").append(notification);
+  notification.toast({delay: 30000});
+  notification.toast('show');
+}

--- a/java/sports-league-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/sports-league-scheduling/src/main/resources/META-INF/resources/app.js
@@ -278,3 +278,32 @@ function copyTextToClipboard(id) {
     document.execCommand("copy");
     document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/spring-boot-integration/src/main/resources/static/app.js
+++ b/java/spring-boot-integration/src/main/resources/static/app.js
@@ -375,3 +375,32 @@ function copyTextToClipboard(id) {
   document.execCommand("copy");
   document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+  let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+  let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+  let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+  let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+  if (xhr.responseJSON && !serverErrorMessage) {
+    serverErrorMessage = JSON.stringify(xhr.responseJSON);
+    serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+    serverErrorId = `----`;
+  }
+
+  console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+  const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+      .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+      .append($(`<div class="toast-body"/>`)
+          .append($(`<p/>`).text(title))
+          .append($(`<pre/>`)
+              .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+          )
+      );
+  $("#notificationPanel").append(notification);
+  notification.toast({delay: 30000});
+  notification.toast('show');
+}

--- a/java/task-assigning/src/main/resources/META-INF/resources/app.js
+++ b/java/task-assigning/src/main/resources/META-INF/resources/app.js
@@ -357,3 +357,32 @@ function copyTextToClipboard(id) {
     document.execCommand("copy");
     document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/tournament-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/tournament-scheduling/src/main/resources/META-INF/resources/app.js
@@ -402,3 +402,32 @@ function copyTextToClipboard(id) {
     document.execCommand("copy");
     document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/java/vehicle-routing/src/main/resources/META-INF/resources/app.js
+++ b/java/vehicle-routing/src/main/resources/META-INF/resources/app.js
@@ -569,3 +569,32 @@ function copyTextToClipboard(id) {
     document.execCommand("copy");
     document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+    let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+    let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+    let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+    let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+    if (xhr.responseJSON && !serverErrorMessage) {
+        serverErrorMessage = JSON.stringify(xhr.responseJSON);
+        serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+        serverErrorId = `----`;
+    }
+
+    console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+    const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+        .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+        .append($(`<div class="toast-body"/>`)
+            .append($(`<p/>`).text(title))
+            .append($(`<pre/>`)
+                .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+            )
+        );
+    $("#notificationPanel").append(notification);
+    notification.toast({delay: 30000});
+    notification.toast('show');
+}

--- a/kotlin/school-timetabling/src/main/resources/META-INF/resources/app.js
+++ b/kotlin/school-timetabling/src/main/resources/META-INF/resources/app.js
@@ -375,3 +375,32 @@ function copyTextToClipboard(id) {
   document.execCommand("copy");
   document.body.removeChild(dummy);
 }
+
+function showError(title, xhr) {
+  let serverErrorMessage = !xhr.responseJSON ? `${xhr.status}: ${xhr.statusText}` : xhr.responseJSON.message;
+  let serverErrorCode = !xhr.responseJSON ? `unknown` : xhr.responseJSON.code;
+  let serverErrorId = !xhr.responseJSON ? `----` : xhr.responseJSON.id;
+  let serverErrorDetails = !xhr.responseJSON ? `no details provided` : xhr.responseJSON.details;
+
+  if (xhr.responseJSON && !serverErrorMessage) {
+    serverErrorMessage = JSON.stringify(xhr.responseJSON);
+    serverErrorCode = xhr.statusText + '(' + xhr.status + ')';
+    serverErrorId = `----`;
+  }
+
+  console.error(title + "\n" + serverErrorMessage + " : " + serverErrorDetails);
+  const notification = $(`<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" style="min-width: 50rem"/>`)
+      .append($(`<div class="toast-header bg-danger">
+                 <strong class="me-auto text-dark">Error</strong>
+                 <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+               </div>`))
+      .append($(`<div class="toast-body"/>`)
+          .append($(`<p/>`).text(title))
+          .append($(`<pre/>`)
+              .append($(`<code/>`).text(serverErrorMessage + "\n\nCode: " + serverErrorCode + "\nError id: " + serverErrorId))
+          )
+      );
+  $("#notificationPanel").append(notification);
+  notification.toast({delay: 30000});
+  notification.toast('show');
+}


### PR DESCRIPTION
## Description of the change

Fixes #973.

This was due to the fact that we removed the WebJar from the quickstarts. Apparently, the error handling was part of the Javascript in those quickstarts.

## Checklist

### Development

- [x] The changes have been covered with tests, if necessary.
- [x] You have a green build, with the exception of the flaky tests.
- [x] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [x] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [x] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.