### PR TITLE
test: add reproducer for score corruption with DSV

### DIFF
--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Vehicle.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Vehicle.java
@@ -1,6 +1,8 @@
 package org.acme.vehiclerouting.domain;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,6 +10,8 @@ import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.lookup.PlanningId;
 import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 
+import ai.timefold.solver.core.api.domain.variable.ShadowSources;
+import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -26,9 +30,14 @@ public class Vehicle implements LocationAware {
 
     private LocalDateTime departureTime;
 
+    private LocalDateTime maxEndTime;
+
     @JsonIdentityReference(alwaysAsId = true)
     @PlanningListVariable
     private List<Visit> visits;
+
+    @ShadowVariable(supplierName = "updateArrivalTime")
+    private LocalDateTime arrivalTime;
 
     public Vehicle() {
     }
@@ -69,12 +78,25 @@ public class Vehicle implements LocationAware {
         return departureTime;
     }
 
+    public LocalDateTime getMaxEndTime() {
+        return maxEndTime;
+    }
+
+    public void setMaxEndTime(LocalDateTime maxEndTime) {
+        this.maxEndTime = maxEndTime;
+    }
+
     public List<Visit> getVisits() {
         return visits;
     }
 
     public void setVisits(List<Visit> visits) {
         this.visits = visits;
+    }
+
+    public Vehicle withMaxEndTime(LocalDateTime maxEndTime) {
+        setMaxEndTime(maxEndTime);
+        return this;
     }
 
     // ************************************************************************
@@ -115,13 +137,40 @@ public class Vehicle implements LocationAware {
     }
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    public LocalDateTime arrivalTime() {
+    public LocalDateTime getArrivalTime() {
+        return arrivalTime;
+    }
+
+    @ShadowSources({"visits", "visits[].arrivalTime"})
+    private LocalDateTime updateArrivalTime() {
         if (visits.isEmpty()) {
             return departureTime;
         }
 
         Visit lastVisit = visits.get(visits.size() - 1);
         return lastVisit.getDepartureTime().plusSeconds(lastVisit.getLocation().getDrivingTimeTo(homeLocation));
+    }
+
+    @JsonIgnore
+    public boolean isShiftFinishedAfterMaxEndTime() {
+        return maxEndTime != null && arrivalTime != null && arrivalTime.isAfter(maxEndTime);
+    }
+
+    @JsonIgnore
+    public long getShiftFinishedDelayInMinutes() {
+        if (maxEndTime == null || arrivalTime == null) {
+            return 0;
+        }
+        return roundDurationToNextOrEqualMinutes(Duration.between(maxEndTime, arrivalTime));
+    }
+
+    private static long roundDurationToNextOrEqualMinutes(Duration duration) {
+        var remainder = duration.minus(duration.truncatedTo(ChronoUnit.MINUTES));
+        var minutes = duration.toMinutes();
+        if (remainder.equals(Duration.ZERO)) {
+            return minutes;
+        }
+        return minutes + 1;
     }
 
     @Override

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Visit.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Visit.java
@@ -7,6 +7,7 @@ import java.time.temporal.ChronoUnit;
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
 import ai.timefold.solver.core.api.domain.lookup.PlanningId;
 import ai.timefold.solver.core.api.domain.variable.InverseRelationShadowVariable;
+import ai.timefold.solver.core.api.domain.variable.NextElementShadowVariable;
 import ai.timefold.solver.core.api.domain.variable.PreviousElementShadowVariable;
 import ai.timefold.solver.core.api.domain.variable.ShadowSources;
 import ai.timefold.solver.core.api.domain.variable.ShadowVariable;
@@ -37,6 +38,8 @@ public class Visit implements LocationAware {
     @JsonIdentityReference(alwaysAsId = true)
     @PreviousElementShadowVariable(sourceVariableName = "visits")
     private Visit previousVisit;
+    @NextElementShadowVariable(sourceVariableName = "visits")
+    private Visit nextVisit;
     @ShadowVariable(supplierName = "arrivalTimeSupplier")
     private LocalDateTime arrivalTime;
 
@@ -109,6 +112,14 @@ public class Visit implements LocationAware {
 
     public void setPreviousVisit(Visit previousVisit) {
         this.previousVisit = previousVisit;
+    }
+
+    public Visit getNextVisit() {
+        return nextVisit;
+    }
+
+    public void setNextVisit(Visit nextVisit) {
+        this.nextVisit = nextVisit;
     }
 
     public LocalDateTime getArrivalTime() {
@@ -191,6 +202,11 @@ public class Visit implements LocationAware {
             return null;
         }
         return getDrivingTimeSecondsFromPreviousStandstill();
+    }
+
+    @JsonIgnore
+    public boolean isAssignedAsLast() {
+        return vehicle != null && nextVisit == null;
     }
 
     @Override

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/rest/VehicleRouteDemoResource.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/rest/VehicleRouteDemoResource.java
@@ -165,7 +165,7 @@ public class VehicleRouteDemoResource {
                 String.valueOf(vehicleSequence.incrementAndGet()),
                 vehicleCapacity.nextInt(),
                 new Location(latitudes.nextDouble(), longitudes.nextDouble()),
-                tomorrowAt(demoData.vehicleStartTime));
+                tomorrowAt(demoData.vehicleStartTime)).withMaxEndTime(tomorrowAt(demoData.vehicleStartTime).plusHours(4));
 
         List<Vehicle> vehicles = Stream.generate(vehicleSupplier)
                 .limit(demoData.vehicleCount)

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProvider.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProvider.java
@@ -12,6 +12,7 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
 
     public static final String VEHICLE_CAPACITY = "vehicleCapacity";
     public static final String SERVICE_FINISHED_AFTER_MAX_END_TIME = "serviceFinishedAfterMaxEndTime";
+    public static final String SHIFT_FINISHED_AFTER_MAX_END_TIME = "shiftFinishedAfterMaxEndTime";
     public static final String MINIMIZE_TRAVEL_TIME = "minimizeTravelTime";
 
     @Override
@@ -19,6 +20,7 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
         return new Constraint[] {
                 vehicleCapacity(factory),
                 serviceFinishedAfterMaxEndTime(factory),
+                shiftFinishedAfterMaxEndTime(factory),
                 minimizeTravelTime(factory)
         };
     }
@@ -41,6 +43,14 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
                 .penalizeLong(HardSoftLongScore.ONE_HARD,
                         Visit::getServiceFinishedDelayInMinutes)
                 .asConstraint(SERVICE_FINISHED_AFTER_MAX_END_TIME);
+    }
+
+    protected Constraint shiftFinishedAfterMaxEndTime(ConstraintFactory factory) {
+        return factory.forEach(Vehicle.class)
+                .filter(Vehicle::isShiftFinishedAfterMaxEndTime)
+                .penalizeLong(HardSoftLongScore.ONE_HARD,
+                        Vehicle::getShiftFinishedDelayInMinutes)
+                .asConstraint(SHIFT_FINISHED_AFTER_MAX_END_TIME);
     }
 
     // ************************************************************************

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProvider.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProvider.java
@@ -5,8 +5,11 @@ import ai.timefold.solver.core.api.score.stream.Constraint;
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory;
 import ai.timefold.solver.core.api.score.stream.ConstraintProvider;
 
+import ai.timefold.solver.core.api.score.stream.Joiners;
 import org.acme.vehiclerouting.domain.Visit;
 import org.acme.vehiclerouting.domain.Vehicle;
+
+import java.util.function.Function;
 
 public class VehicleRoutingConstraintProvider implements ConstraintProvider {
 
@@ -47,9 +50,14 @@ public class VehicleRoutingConstraintProvider implements ConstraintProvider {
 
     protected Constraint shiftFinishedAfterMaxEndTime(ConstraintFactory factory) {
         return factory.forEach(Vehicle.class)
-                .filter(Vehicle::isShiftFinishedAfterMaxEndTime)
+                // Added the join with the last visit to make sure constraint is triggered by potential changes on the visit,
+                // even though it should not be necessary as the Vehicle.arrivalTime shadow var should trigger the constraint?
+                .join(Visit.class,
+                Joiners.equal(Function.identity(), Visit::getVehicle),
+                Joiners.filtering((vehicle,visit) -> (visit.isAssignedAsLast() && visit.getVehicle().equals(vehicle))))
+                .filter((vehicle, lastVisit) -> vehicle.isShiftFinishedAfterMaxEndTime())
                 .penalizeLong(HardSoftLongScore.ONE_HARD,
-                        Vehicle::getShiftFinishedDelayInMinutes)
+                        (vehicle, lastVisit) -> vehicle.getShiftFinishedDelayInMinutes())
                 .asConstraint(SHIFT_FINISHED_AFTER_MAX_END_TIME);
     }
 

--- a/java/vehicle-routing/src/main/resources/application.properties
+++ b/java/vehicle-routing/src/main/resources/application.properties
@@ -46,3 +46,4 @@ quarkus.swagger-ui.always-include=true
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
 
+%test.quarkus.timefold.solver.environment-mode=TRACKED_FULL_ASSERT


### PR DESCRIPTION
This is a reproducer of a score corruption happening with DSV when the genuine planning entity gets a new shadow variable depending on the shadow variables of entities contained in a planning list variable.

Added a join to make sure the constraint is triggered, the score corruption is still present:

```
2026-01-07 18:32:28,856 INFO  [ai.timefold.solver.core.impl.solver.DefaultSolver] (pool-8-thread-1) Solving started: time spent (20), best score (0hard/0soft), environment mode (TRACKED_FULL_ASSERT), move thread count (NONE), random (JDK with seed 0).
2026-01-07 18:32:28,856 INFO  [ai.timefold.solver.core.impl.solver.DefaultSolver] (pool-8-thread-1) Problem scale: entity count (6), variable count (6), approximate value count (77), approximate problem scale (3.96137 × 10^120).
2026-01-07 18:32:28,870 ERROR [org.acme.vehiclerouting.rest.VehicleRoutePlanResource] (pool-8-thread-1) Failed solving jobId (b10c1805-5fbc-4b6c-930a-b506d3029a01).: ai.timefold.solver.core.impl.solver.exception.ScoreCorruptionException: Score corruption (126hard): the workingScore (-76init/0hard/-664soft) is not the uncorruptedScore (-76init/-126hard/-664soft) after completedAction (1 {null -> 1[0]}):
Score corruption analysis:
  The corrupted scoreDirector has no ConstraintMatch(es) which should not be there.
  The corrupted scoreDirector has 1 ConstraintMatch(es) which are missing:
    org.acme.vehiclerouting.domain/shiftFinishedAfterMaxEndTime/[1, 1]=-126hard/0soft
  Maybe there is a bug in the score constraints of those ConstraintMatch(s).
  Maybe a score constraint doesn't select all the entities it depends on,
    but discovers some transitively through a reference from the selected entity.
    This corrupts incremental score calculation,
    because the constraint is not re-evaluated if the transitively discovered entity changes.
Shadow variable corruption in the corrupted scoreDirector:
  None
```

Q: It seems there is shadow variable corruption, even though it is not reported in the `TRACKED_FULL_ASSERT` output above?