### PR TITLE
chore: improve constraint filtering for scheduling

### DIFF
--- a/java/conference-scheduling/src/main/java/org/acme/conferencescheduling/solver/ConferenceSchedulingConstraintProvider.java
+++ b/java/conference-scheduling/src/main/java/org/acme/conferencescheduling/solver/ConferenceSchedulingConstraintProvider.java
@@ -353,8 +353,8 @@ public class ConferenceSchedulingConstraintProvider implements ConstraintProvide
     Constraint themeTrackRoomStability(ConstraintFactory factory) {
         return factory.forEachUniquePair(Talk.class,
                 equal(talk -> talk.getTimeslot().getStartDateTime().toLocalDate()),
-                filtering((talk1, talk2) -> talk2.overlappingThemeTrackCount(talk1) > 0))
-                .filter((talk1, talk2) -> !talk1.getRoom().equals(talk2.getRoom()))
+                filtering((talk1, talk2) -> talk2.overlappingThemeTrackCount(talk1) > 0),
+                filtering((talk1, talk2) -> !talk1.getRoom().equals(talk2.getRoom())))
                 .penalize(HardSoftScore.ofSoft(10), (talk1, talk2) -> talk1.overlappingThemeTrackCount(talk2) *
                         talk1.combinedDurationInMinutes(talk2))
                 .justifyWith(
@@ -446,8 +446,8 @@ public class ConferenceSchedulingConstraintProvider implements ConstraintProvide
 
     Constraint languageDiversity(ConstraintFactory factory) {
         return factory.forEachUniquePair(Talk.class,
-                equal(Talk::getTimeslot))
-                .filter((talk1, talk2) -> !talk1.getLanguage().equals(talk2.getLanguage()))
+                equal(Talk::getTimeslot),
+                filtering((talk1, talk2) -> !talk1.getLanguage().equals(talk2.getLanguage())))
                 .reward(HardSoftScore.ofSoft(10), (talk1, talk2) -> talk1.getTimeslot().getDurationInMinutes())
                 .justifyWith((talk, talk2, score) -> new DiversityTalkJustification("language", talk, talk.getLanguage(), talk2,
                         talk2.getLanguage()))
@@ -455,9 +455,9 @@ public class ConferenceSchedulingConstraintProvider implements ConstraintProvide
     }
 
     Constraint sameDayTalks(ConstraintFactory factory) {
-        return factory.forEachUniquePair(Talk.class)
-                .filter((talk1, talk2) -> !talk1.getTimeslot().isOnSameDayAs(talk2.getTimeslot()) &&
-                        (talk1.overlappingContentCount(talk2) > 0 || talk1.overlappingThemeTrackCount(talk2) > 0))
+        return factory.forEachUniquePair(Talk.class,
+                filtering((talk1, talk2) -> !talk1.getTimeslot().isOnSameDayAs(talk2.getTimeslot()) &&
+                        (talk1.overlappingContentCount(talk2) > 0 || talk1.overlappingThemeTrackCount(talk2) > 0)))
                 .penalize(HardSoftScore.ofSoft(10),
                         (talk1, talk2) -> (talk2.overlappingThemeTrackCount(talk1) + talk2.overlappingContentCount(talk1))
                                 * talk1.combinedDurationInMinutes(talk2))

--- a/java/hello-world/src/main/java/org/acme/schooltimetabling/solver/TimetableConstraintProvider.java
+++ b/java/hello-world/src/main/java/org/acme/schooltimetabling/solver/TimetableConstraintProvider.java
@@ -36,10 +36,10 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         return constraintFactory
                 // Select each pair of 2 different lessons ...
                 .forEachUniquePair(Lesson.class,
+                        // ... in the same room (most selective first) ...
+                        Joiners.equal(Lesson::getRoom),
                         // ... in the same timeslot ...
-                        Joiners.equal(Lesson::getTimeslot),
-                        // ... in the same room ...
-                        Joiners.equal(Lesson::getRoom))
+                        Joiners.equal(Lesson::getTimeslot))
                 // ... and penalize each pair with a hard weight.
                 .penalize(HardSoftScore.ONE_HARD)
                 .justifyWith((lesson1, lesson2, score) -> new RoomConflictJustification(lesson1.getRoom(), lesson1, lesson2))
@@ -50,8 +50,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A teacher can teach at most one lesson at the same time.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getTeacher))
+                        Joiners.equal(Lesson::getTeacher),
+                        Joiners.equal(Lesson::getTimeslot))
                 .penalize(HardSoftScore.ONE_HARD)
                 .justifyWith(
                         (lesson1, lesson2, score) -> new TeacherConflictJustification(lesson1.getTeacher(), lesson1, lesson2))
@@ -62,8 +62,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A student can attend at most one lesson at the same time.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getStudentGroup))
+                        Joiners.equal(Lesson::getStudentGroup),
+                        Joiners.equal(Lesson::getTimeslot))
                 .penalize(HardSoftScore.ONE_HARD)
                 .justifyWith((lesson1, lesson2, score) -> new StudentGroupConflictJustification(lesson1.getStudentGroup(), lesson1, lesson2))
                 .asConstraint("Student group conflict");
@@ -73,8 +73,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A teacher prefers to teach in a single room.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTeacher))
-                .filter((lesson1, lesson2) -> lesson1.getRoom() != lesson2.getRoom())
+                        Joiners.equal(Lesson::getTeacher),
+                        Joiners.filtering((lesson1, lesson2) -> lesson1.getRoom() != lesson2.getRoom()))
                 .penalize(HardSoftScore.ONE_SOFT)
                 .justifyWith((lesson1, lesson2, score) -> new TeacherRoomStabilityJustification(lesson1.getTeacher(), lesson1, lesson2))
                 .asConstraint("Teacher room stability");

--- a/java/school-timetabling/src/main/java/org/acme/schooltimetabling/solver/TimetableConstraintProvider.java
+++ b/java/school-timetabling/src/main/java/org/acme/schooltimetabling/solver/TimetableConstraintProvider.java
@@ -31,10 +31,10 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         return constraintFactory
                 // Select each pair of 2 different lessons ...
                 .forEachUniquePair(Lesson.class,
+                        // ... in the same room (most selective first) ...
+                        Joiners.equal(Lesson::getRoom),
                         // ... in the same timeslot ...
-                        Joiners.equal(Lesson::getTimeslot),
-                        // ... in the same room ...
-                        Joiners.equal(Lesson::getRoom))
+                        Joiners.equal(Lesson::getTimeslot))
                 // ... and penalize each pair with a hard weight.
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Room conflict");
@@ -44,8 +44,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A teacher can teach at most one lesson at the same time.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getTeacher))
+                        Joiners.equal(Lesson::getTeacher),
+                        Joiners.equal(Lesson::getTimeslot))
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Teacher conflict");
     }
@@ -54,8 +54,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A student can attend at most one lesson at the same time.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getStudentGroup))
+                        Joiners.equal(Lesson::getStudentGroup),
+                        Joiners.equal(Lesson::getTimeslot))
                 .penalize(HardSoftScore.ONE_HARD)
                 .asConstraint("Student group conflict");
     }
@@ -64,8 +64,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A teacher prefers to teach in a single room.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTeacher))
-                .filter((lesson1, lesson2) -> lesson1.getRoom() != lesson2.getRoom())
+                        Joiners.equal(Lesson::getTeacher),
+                        Joiners.filtering((lesson1, lesson2) -> lesson1.getRoom() != lesson2.getRoom()))
                 .penalize(HardSoftScore.ONE_SOFT)
                 .asConstraint("Teacher room stability");
     }

--- a/java/spring-boot-integration/src/main/java/org/acme/schooltimetabling/solver/TimetableConstraintProvider.java
+++ b/java/spring-boot-integration/src/main/java/org/acme/schooltimetabling/solver/TimetableConstraintProvider.java
@@ -31,10 +31,10 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         return constraintFactory
                 // Select each pair of 2 different lessons ...
                 .forEachUniquePair(Lesson.class,
+                        // ... in the same room (most selective first) ...
+                        Joiners.equal(Lesson::getRoom),
                         // ... in the same timeslot ...
-                        Joiners.equal(Lesson::getTimeslot),
-                        // ... in the same room ...
-                        Joiners.equal(Lesson::getRoom))
+                        Joiners.equal(Lesson::getTimeslot))
                 // ... and penalize each pair with a hard weight.
                 .penalize(HardSoftScore.ONE_HARD)
                 .justifyWith((lesson1, lesson2, score) -> new RoomConflictJustification(lesson1.getRoom(), lesson1, lesson2))
@@ -45,8 +45,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A teacher can teach at most one lesson at the same time.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getTeacher))
+                        Joiners.equal(Lesson::getTeacher),
+                        Joiners.equal(Lesson::getTimeslot))
                 .penalize(HardSoftScore.ONE_HARD)
                 .justifyWith(
                         (lesson1, lesson2, score) -> new TeacherConflictJustification(lesson1.getTeacher(), lesson1, lesson2))
@@ -57,8 +57,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A student can attend at most one lesson at the same time.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTimeslot),
-                        Joiners.equal(Lesson::getStudentGroup))
+                        Joiners.equal(Lesson::getStudentGroup),
+                        Joiners.equal(Lesson::getTimeslot))
                 .penalize(HardSoftScore.ONE_HARD)
                 .justifyWith((lesson1, lesson2, score) -> new StudentGroupConflictJustification(lesson1.getStudentGroup(), lesson1, lesson2))
                 .asConstraint("Student group conflict");
@@ -68,8 +68,8 @@ public class TimetableConstraintProvider implements ConstraintProvider {
         // A teacher prefers to teach in a single room.
         return constraintFactory
                 .forEachUniquePair(Lesson.class,
-                        Joiners.equal(Lesson::getTeacher))
-                .filter((lesson1, lesson2) -> lesson1.getRoom() != lesson2.getRoom())
+                        Joiners.equal(Lesson::getTeacher),
+                        Joiners.filtering((lesson1, lesson2) -> lesson1.getRoom() != lesson2.getRoom()))
                 .penalize(HardSoftScore.ONE_SOFT)
                 .justifyWith((lesson1, lesson2, score) -> new TeacherRoomStabilityJustification(lesson1.getTeacher(), lesson1, lesson2))
                 .asConstraint("Teacher room stability");


### PR DESCRIPTION
This PR applies Timefold [performance tips and tricks](https://docs.timefold.ai/timefold-solver/latest/constraints-and-score/performance) to the quickstart.

## Summary of the following constraint profiling tables

### Conference Scheduling

1. **Same day talks**: -0.82s (-50.93%) - from 1.61s to 0.79s
2. **Language diversity**: -0.25s (-26.88%) - from 0.93s to 0.68s

### School Timetabling

Changes are too small and would require more datapoints to be conclusive

## Details

### Conference Scheduling

#### Before constraint improvements

|                                                    | Time Spent | Of Total |
| :------------------------------------------------- | ---------: | -------: |
| Work shared by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1... |     2,16 s |   7,77 % |
| 19: Theme track room stability                     |     2,11 s |   7,59 % |
| 33: Speaker conflict                               |     2,05 s |   7,36 % |
| 11: Same day talks                                 |     1,61 s |   5,77 % |
| 20: Theme track conflict                           |     1,39 s |   4,98 % |
| 30: Consecutive talks pause                        |     1,36 s |   4,86 % |
| 18: Sector conflict                                |     1,30 s |   4,68 % |
| 35: Room conflict                                  |     1,26 s |   4,52 % |
| 10: Popular talks                                  |     1,25 s |   4,49 % |
| 16: Audience type theme track conflict             |     1,19 s |   4,28 % |
| 13: Content conflict                               |     1,16 s |   4,18 % |
| 1: Speaker makespan                                |     1,13 s |   4,04 % |
| 14: Content audience level flow violation          |     1,08 s |   3,89 % |
| 31: Talk mutually-exclusive-talks tags             |     1,05 s |   3,78 % |
| 15: Audience level diversity                       |     1,05 s |   3,76 % |
| 12: Language diversity                             |     0,93 s |   3,35 % |
| 17: Audience type diversity                        |     0,92 s |   3,29 % |
| 32: Talk prerequisite talks                        |     0,79 s |   2,83 % |
| 34: Speaker unavailable timeslot                   |     0,46 s |   1,64 % |
| 29: Crowd control                                  |     0,33 s |   1,20 % |
| 28: Speaker required timeslot tags                 |     0,24 s |   0,85 % |
| 9: Speaker preferred timeslot tags                 |     0,23 s |   0,81 % |
| 27: Speaker prohibited timeslot tags               |     0,21 s |   0,76 % |
| 8: Speaker undesired timeslot tags                 |     0,20 s |   0,72 % |
| 24: Speaker required room tags                     |     0,19 s |   0,69 % |
| 4: Speaker undesired room tags                     |     0,19 s |   0,69 % |
| 23: Speaker prohibited room tags                   |     0,19 s |   0,68 % |
| 26: Talk required timeslot tags                    |     0,19 s |   0,68 % |
| 7: Talk preferred timeslot tags                    |     0,19 s |   0,68 % |
| 2: Talk undesired room tags                        |     0,19 s |   0,67 % |
| 5: Speaker preferred room tags                     |     0,19 s |   0,67 % |
| 22: Talk required room tags                        |     0,19 s |   0,67 % |
| 25: Talk prohibited timeslot tags                  |     0,19 s |   0,67 % |
| 3: Talk preferred room tags                        |     0,18 s |   0,65 % |
| 6: Talk undesired timeslot tags                    |     0,18 s |   0,65 % |
| 21: Talk prohibited room tags                      |     0,18 s |   0,64 % |
| 36: Room unavailable timeslot                      |     0,13 s |   0,47 % |
| Work shared by 1, 2, 3                             |     0,03 s |   0,10 % |

#### After constraint improvements

|                                                    | Time Spent | Of Total |
| :------------------------------------------------- | ---------: | -------: |
| Work shared by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1... |     2,17 s |   7,80 % |
| 33: Speaker conflict                               |     2,16 s |   7,78 % |
| 19: Theme track room stability                     |     2,03 s |   7,32 % |
| 20: Theme track conflict                           |     1,45 s |   5,22 % |
| 30: Consecutive talks pause                        |     1,44 s |   5,19 % |
| 18: Sector conflict                                |     1,36 s |   4,88 % |
| 35: Room conflict                                  |     1,31 s |   4,73 % |
| 10: Popular talks                                  |     1,30 s |   4,69 % |
| 16: Audience type theme track conflict             |     1,25 s |   4,51 % |
| 13: Content conflict                               |     1,23 s |   4,44 % |
| 1: Speaker makespan                                |     1,17 s |   4,22 % |
| 14: Content audience level flow violation          |     1,14 s |   4,11 % |
| 31: Talk mutually-exclusive-talks tags             |     1,12 s |   4,02 % |
| 15: Audience level diversity                       |     1,11 s |   3,98 % |
| 17: Audience type diversity                        |     0,97 s |   3,48 % |
| 32: Talk prerequisite talks                        |     0,82 s |   2,97 % |
| 11: Same day talks                                 |     0,79 s |   2,86 % |
| 12: Language diversity                             |     0,68 s |   2,45 % |
| 34: Speaker unavailable timeslot                   |     0,47 s |   1,69 % |
| 29: Crowd control                                  |     0,35 s |   1,25 % |
| 28: Speaker required timeslot tags                 |     0,25 s |   0,89 % |
| 9: Speaker preferred timeslot tags                 |     0,24 s |   0,86 % |
| 27: Speaker prohibited timeslot tags               |     0,22 s |   0,78 % |
| 8: Speaker undesired timeslot tags                 |     0,21 s |   0,76 % |
| 5: Speaker preferred room tags                     |     0,21 s |   0,74 % |
| 23: Speaker prohibited room tags                   |     0,20 s |   0,73 % |
| 24: Speaker required room tags                     |     0,20 s |   0,73 % |
| 4: Speaker undesired room tags                     |     0,20 s |   0,72 % |
| 22: Talk required room tags                        |     0,20 s |   0,71 % |
| 26: Talk required timeslot tags                    |     0,20 s |   0,71 % |
| 25: Talk prohibited timeslot tags                  |     0,20 s |   0,71 % |
| 2: Talk undesired room tags                        |     0,19 s |   0,70 % |
| 3: Talk preferred room tags                        |     0,19 s |   0,70 % |
| 7: Talk preferred timeslot tags                    |     0,19 s |   0,70 % |
| 21: Talk prohibited room tags                      |     0,19 s |   0,69 % |
| 6: Talk undesired timeslot tags                    |     0,19 s |   0,69 % |
| 36: Room unavailable timeslot                      |     0,14 s |   0,50 % |
| Work shared by 1, 2, 3                             |     0,03 s |   0,11 % |

### School Timetabling

#### Before constraint improvements

|                                                    | Time Spent | Of Total |
| :------------------------------------------------- | ---------: | -------: |
| 2: Teacher time efficiency                         |     5,60 s |  20,92 % |
| 6: Room conflict                                   |     5,21 s |  19,45 % |
| 4: Student group conflict                          |     3,58 s |  13,35 % |
| 5: Teacher conflict                                |     3,50 s |  13,08 % |
| 3: Teacher room stability                          |     3,13 s |  11,68 % |
| 1: Student group subject variety                   |     3,07 s |  11,47 % |
| Work shared by 1, 2, 3, 4, 5, 6                    |     2,69 s |  10,05 % |

#### After constraint improvements

|                                                    | Time Spent | Of Total |
| :------------------------------------------------- | ---------: | -------: |
| 2: Teacher time efficiency                         |     5,67 s |  21,16 % |
| 6: Room conflict                                   |     5,17 s |  19,28 % |
| 4: Student group conflict                          |     3,58 s |  13,35 % |
| 5: Teacher conflict                                |     3,42 s |  12,75 % |
| 3: Teacher room stability                          |     3,22 s |  12,00 % |
| 1: Student group subject variety                   |     3,07 s |  11,45 % |
| Work shared by 1, 2, 3, 4, 5, 6                    |     2,68 s |  10,02 % |

## Checklist

### Development

- [ ] The changes have been covered with tests, if necessary.
- [ ] You have a green build, with the exception of the flaky tests.
- [ ] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [ ] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [ ] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.