### PR TITLE
fix(code): use strict equality in code

### DIFF
--- a/java/bed-allocation/src/main/resources/META-INF/resources/app.js
+++ b/java/bed-allocation/src/main/resources/META-INF/resources/app.js
@@ -170,7 +170,7 @@ function renderScheduleByRoom(schedule) {
             unassignedPatientElement.append(preferredEquipmentDiv);
             if (stay.patientPreferredEquipments && stay.patientPreferredEquipments.length > 0) {
                 stay.patientPreferredEquipments
-                    .filter(e => stay.patientRequiredEquipments.indexOf(e) == -1)
+                    .filter(e => stay.patientRequiredEquipments.indexOf(e) === -1)
                     .sort()
                     .forEach(e => preferredEquipmentDiv.append($(`<span class="badge text-bg-secondary m-1"/>`).text(e)));
             }


### PR DESCRIPTION
Was reading through java/bed-allocation/src/main/resources/META-INF/resources/app.js and the loose equality here can coerce values in ways that are hard to spot later. I tightened it to strict equality.