### PR TITLE
fix: map correct field

### DIFF
--- a/java/bed-allocation/src/main/resources/META-INF/resources/app.js
+++ b/java/bed-allocation/src/main/resources/META-INF/resources/app.js
@@ -303,7 +303,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/conference-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/conference-scheduling/src/main/resources/META-INF/resources/app.js
@@ -445,7 +445,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/employee-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/employee-scheduling/src/main/resources/META-INF/resources/app.js
@@ -358,7 +358,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/facility-location/src/main/resources/META-INF/resources/app.js
+++ b/java/facility-location/src/main/resources/META-INF/resources/app.js
@@ -227,7 +227,7 @@ function analyze() {
 
         let row = $(`<tr/>`);
         row.append($(`<td/>`).html(icon))
-            .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+            .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
             .append($(`<td/>`).text(constraintAnalysis.type))
             .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
             .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/flight-crew-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/flight-crew-scheduling/src/main/resources/META-INF/resources/app.js
@@ -331,7 +331,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/food-packaging/src/main/resources/META-INF/resources/app.js
+++ b/java/food-packaging/src/main/resources/META-INF/resources/app.js
@@ -273,7 +273,7 @@ function analyze() {
 
         let row = $(`<tr/>`);
         row.append($(`<td/>`).html(icon))
-            .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+            .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
             .append($(`<td/>`).text(constraintAnalysis.type))
             .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
             .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/maintenance-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/maintenance-scheduling/src/main/resources/META-INF/resources/app.js
@@ -325,7 +325,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/meeting-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/meeting-scheduling/src/main/resources/META-INF/resources/app.js
@@ -338,7 +338,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/project-job-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/project-job-scheduling/src/main/resources/META-INF/resources/app.js
@@ -360,7 +360,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/school-timetabling/src/main/resources/META-INF/resources/app.js
+++ b/java/school-timetabling/src/main/resources/META-INF/resources/app.js
@@ -329,7 +329,7 @@ function analyze() {
 
         let row = $(`<tr/>`);
         row.append($(`<td/>`).html(icon))
-          .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+          .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
           .append($(`<td/>`).text(constraintAnalysis.type))
           .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
           .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/sports-league-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/sports-league-scheduling/src/main/resources/META-INF/resources/app.js
@@ -216,7 +216,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/spring-boot-integration/src/main/resources/static/app.js
+++ b/java/spring-boot-integration/src/main/resources/static/app.js
@@ -329,7 +329,7 @@ function analyze() {
 
         let row = $(`<tr/>`);
         row.append($(`<td/>`).html(icon))
-            .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+            .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
             .append($(`<td/>`).text(constraintAnalysis.type))
             .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
             .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/task-assigning/src/main/resources/META-INF/resources/app.js
+++ b/java/task-assigning/src/main/resources/META-INF/resources/app.js
@@ -295,7 +295,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/tournament-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/java/tournament-scheduling/src/main/resources/META-INF/resources/app.js
@@ -340,7 +340,7 @@ function analyze() {
 
                 let row = $(`<tr/>`);
                 row.append($(`<td/>`).html(icon))
-                    .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+                    .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
                     .append($(`<td/>`).text(constraintAnalysis.type))
                     .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
                     .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/java/vehicle-routing/src/main/resources/META-INF/resources/score-analysis.js
+++ b/java/vehicle-routing/src/main/resources/META-INF/resources/score-analysis.js
@@ -91,7 +91,7 @@ function visualizeConstraintAnalysis(analysisTBody, constraintIndex, constraintA
 
     let row = $(`<tr/>`);
     row.append($(`<td/>`).html(icon))
-        .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+        .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
         .append($(`<td/>`).text(constraintAnalysis.type))
         .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
         .append($(`<td/>`).text(constraintAnalysis.weight))

--- a/kotlin/school-timetabling/src/main/resources/META-INF/resources/app.js
+++ b/kotlin/school-timetabling/src/main/resources/META-INF/resources/app.js
@@ -329,7 +329,7 @@ function analyze() {
 
         let row = $(`<tr/>`);
         row.append($(`<td/>`).html(icon))
-            .append($(`<td/>`).text(constraintAnalysis.name).css({textAlign: 'left'}))
+            .append($(`<td/>`).text(constraintAnalysis.id).css({textAlign: 'left'}))
             .append($(`<td/>`).text(constraintAnalysis.type))
             .append($(`<td/>`).html(`<b>${constraintAnalysis.matches.length}</b>`))
             .append($(`<td/>`).text(constraintAnalysis.weight))


### PR DESCRIPTION
## Description of the change

The ConstraintRef record was [changed](https://github.com/TimefoldAI/timefold-solver/commit/c697e858eb4d454c22b145a9f916eb10cdaebf58), but this is what gets exposed if you expose ScoreAnalysis<Score> directly.
As a result, currently, the constraint names are not shown when opening the Score Analysis popup in any of the quickstarts.

## Checklist

### Development

- [x] The changes have been covered with tests, if necessary.
- [x] You have a green build, with the exception of the flaky tests.
- [x] UI and JS files are fully tested, the user interface works for all modules affected by your changes (e.g., solve and analyze buttons).
- [x] The network calls work for all modules affected by your changes (e.g., solving a problem).
- [x] The console messages are validated for all modules affected by your changes.

### Code Review

- [ ] This pull request includes an explanatory title and description.
- [ ] The GitHub issue is linked.
- [ ] At least one other engineer has approved the changes.
- [ ] After PR is merged, inform the reporter.