### PR TITLE
deps: upgrade Quarkus to 3.37.2

### DIFF
--- a/getting-started/quarkus-integration-kotlin/pom.xml
+++ b/getting-started/quarkus-integration-kotlin/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.kotlin>2.4.0</version.kotlin>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 

--- a/use-cases/bed-allocation/pom.xml
+++ b/use-cases/bed-allocation/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/bed-allocation/src/main/resources/application.properties
+++ b/use-cases/bed-allocation/src/main/resources/application.properties
@@ -45,3 +45,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/0medium/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/conference-scheduling/pom.xml
+++ b/use-cases/conference-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/conference-scheduling/src/main/resources/application.properties
+++ b/use-cases/conference-scheduling/src/main/resources/application.properties
@@ -45,3 +45,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/employee-scheduling/src/main/resources/application.properties
+++ b/use-cases/employee-scheduling/src/main/resources/application.properties
@@ -43,3 +43,6 @@ quarkus.swagger-ui.always-include=true
 ########################
 
 %test.quarkus.timefold.solver.termination.spent-limit=10s
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/facility-location/src/main/resources/application.properties
+++ b/use-cases/facility-location/src/main/resources/application.properties
@@ -45,3 +45,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/flight-crew-scheduling/pom.xml
+++ b/use-cases/flight-crew-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/flight-crew-scheduling/src/main/resources/application.properties
+++ b/use-cases/flight-crew-scheduling/src/main/resources/application.properties
@@ -45,3 +45,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/food-packaging/pom.xml
+++ b/use-cases/food-packaging/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/food-packaging/src/main/resources/application.properties
+++ b/use-cases/food-packaging/src/main/resources/application.properties
@@ -42,3 +42,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/0medium/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/src/main/resources/application.properties
+++ b/use-cases/maintenance-scheduling/src/main/resources/application.properties
@@ -45,3 +45,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/meeting-scheduling/pom.xml
+++ b/use-cases/meeting-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
     <version.org.apache.commons.text>1.15.0</version.org.apache.commons.text>
 

--- a/use-cases/meeting-scheduling/src/main/resources/application.properties
+++ b/use-cases/meeting-scheduling/src/main/resources/application.properties
@@ -43,3 +43,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/0medium/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/order-picking/src/main/resources/application.properties
+++ b/use-cases/order-picking/src/main/resources/application.properties
@@ -43,3 +43,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/project-job-scheduling/pom.xml
+++ b/use-cases/project-job-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/project-job-scheduling/src/main/resources/application.properties
+++ b/use-cases/project-job-scheduling/src/main/resources/application.properties
@@ -43,3 +43,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*medium/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "3.36.3"
+    id "io.quarkus" version "3.37.2"
 }
 
-def quarkusVersion = "3.36.3"
+def quarkusVersion = "3.37.2"
 def timefoldVersion = "999-SNAPSHOT"
 def profile = System.properties['profile'] ?: ''
 def enterprise = System.properties['enterprise'] ?: ''

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/school-timetabling/src/main/resources/application.properties
+++ b/use-cases/school-timetabling/src/main/resources/application.properties
@@ -45,3 +45,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/sports-league-scheduling/pom.xml
+++ b/use-cases/sports-league-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/sports-league-scheduling/src/main/resources/application.properties
+++ b/use-cases/sports-league-scheduling/src/main/resources/application.properties
@@ -43,3 +43,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/task-assigning/pom.xml
+++ b/use-cases/task-assigning/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
     <version.org.apache.commons.text>1.15.0</version.org.apache.commons.text>
 

--- a/use-cases/task-assigning/src/main/resources/application.properties
+++ b/use-cases/task-assigning/src/main/resources/application.properties
@@ -43,3 +43,6 @@ quarkus.swagger-ui.always-include=true
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=[0]hard/[*/*/*]soft
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/tournament-scheduling/pom.xml
+++ b/use-cases/tournament-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/tournament-scheduling/src/main/resources/application.properties
+++ b/use-cases/tournament-scheduling/src/main/resources/application.properties
@@ -42,3 +42,6 @@ quarkus.swagger-ui.always-include=true
 ########################
 
 %test.quarkus.timefold.solver.termination.spent-limit=10s
+
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.36.3</version.io.quarkus>
+    <version.io.quarkus>3.37.2</version.io.quarkus>
     <version.ai.timefold.solver>999-SNAPSHOT</version.ai.timefold.solver>
 
     <version.compiler.plugin>3.15.0</version.compiler.plugin>

--- a/use-cases/vehicle-routing/src/main/resources/application.properties
+++ b/use-cases/vehicle-routing/src/main/resources/application.properties
@@ -48,3 +48,5 @@ quarkus.swagger-ui.always-include=true
 %test.quarkus.timefold.solver.termination.spent-limit=1h
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/0medium/*soft
 
+# Workaround for https://github.com/quarkusio/quarkus/issues/55362
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false


### PR DESCRIPTION
Upgrades the Quarkus version disabling the bytecode-generated Jackson (de)serializers.