### PR TITLE
fix: correct version property use

### DIFF
--- a/getting-started/service/src/main/java/com/acme/schooltimetabling/rest/TimetableResource.java
+++ b/getting-started/service/src/main/java/com/acme/schooltimetabling/rest/TimetableResource.java
@@ -7,6 +7,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 @Tag(name = "School Timetabling",
         description = "School timetabling service assigning lessons to timeslots.") // OpenAPI documentation annotation
-@Path("/v1/timetables")
+@Path("/timetables")
 public interface TimetableResource extends ModelRest {
 }

--- a/getting-started/service/src/main/resources/application.properties
+++ b/getting-started/service/src/main/resources/application.properties
@@ -13,8 +13,8 @@ quarkus.log.level=INFO
 # Model information
 ########################
 
+model.api.version=v1
 timefold.application.name=my-model
-timefold.application.version=v1
 
 timefold.application.contact.email=example@acme.com
 timefold.application.contact.name=A.C.M.E.


### PR DESCRIPTION
The Getting Started Experience accidently left users with a double version prefix. 

This fixes https://github.com/TimefoldAI/timefold-solver-enterprise/issues/774