### PR TITLE
fix: Order Picking score UI shows undefinedhard/undefinedsoft

### DIFF
--- a/use-cases/order-picking/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/order-picking/src/main/resources/META-INF/resources/app.js
@@ -43,12 +43,7 @@ refreshSolution();
 function printSolutionScore(schedule) {
     const score = schedule.score;
     $("#info").text(`This dataset has ${schedule.trolleys.length} trolleys which need to execute ${schedule.pickTasks.length} picking tasks.`);
-
-    if (score == null) {
-        $("#score").text("Score: ?");
-    } else {
-        $("#score").text(`Score: ${score.hardScore}hard/${score.softScore}soft`);
-    }
+    $("#score").text("Score: " + (score == null ? "?" : score));
 }
 
 function updateWelcomeMessage(solverWasNeverStarted) {
@@ -621,7 +616,12 @@ function analyze() {
 }
 
 function getScoreComponents(score) {
-    let components = {hard: score.hardScore, medium: score?.mediumScore ?? 0, soft: score.softScore};
+    let components = {hard: 0, medium: 0, soft: 0};
+
+    $.each([...score.matchAll(/(-?\d*(\.\d+)?)(hard|medium|soft)/g)], (i, parts) => {
+        components[parts[3]] = parseFloat(parts[1], 10);
+    });
+
     return components;
 }
 


### PR DESCRIPTION
## Summary
- Fixes #1103: Order Picking UI showed `Score: undefinedhard/undefinedsoft` because it treated `solution.score` as an object with `hardScore`/`softScore`, while HardSoftScore is JSON-serialized as a string (e.g. `0hard/-160soft`).
- Display the score string directly (same pattern as the other quickstarts).
- Fix `getScoreComponents` to parse the score string so score analysis sorting/typing works.

## Test plan
- [x] `mvn -B test` in `use-cases/order-picking` (42 tests, 0 failures; 2 skipped env tests)
- [x] Local sanity check: string score `"0hard/-160soft"` renders correctly; old object-property access reproduces `undefinedhard/undefinedsoft`
- [ ] Manual UI: open Order Picking, solve, confirm score label and score analysis modal


Made with [Cursor](https://cursor.com)