### PR TITLE
fix: replace deprecated platform termination properties (#1176)

### DIFF
--- a/getting-started/service/src/main/resources/application.properties
+++ b/getting-started/service/src/main/resources/application.properties
@@ -4,7 +4,7 @@ ai.timefold.storage.ttl=P1D
 
 ai.timefold.model.default-config.termination.spent-limit=PT30M
 ai.timefold.model.default-config.termination.unimproved-spent-limit=PT5M
-ai.timefold.platform.termination.spent-limit=PT30S
+timefold.model.termination.spent-limit=PT30S
 
 quarkus.log.min-level=INFO
 quarkus.log.level=INFO

--- a/use-cases/bed-allocation/src/main/resources/application.properties
+++ b/use-cases/bed-allocation/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 ########################
 
 # The solver runs for 30 seconds. To run for 5 minutes use "PT5M" and for 2 hours use "PT2H".
-ai.timefold.platform.termination.spent-limit=PT30S
+timefold.model.termination.spent-limit=PT30S
 
 # Temporary comment this out to detect bugs in your code (lowers performance)
 # quarkus.timefold.solver.environment-mode=FULL_ASSERT
@@ -61,5 +61,5 @@ quarkus.swagger-ui.always-include=true
 ########################
 
 # Effectively disable spent-time termination in favor of the best-score-limit
-%test.ai.timefold.platform.termination.spent-limit=PT1H
+%test.timefold.model.termination.spent-limit=PT1H
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/0medium/*soft

--- a/use-cases/conference-scheduling/src/main/resources/application.properties
+++ b/use-cases/conference-scheduling/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 ########################
 
 # The solver runs for 30 seconds. To run for 5 minutes use "PT5M" and for 2 hours use "PT2H".
-ai.timefold.platform.termination.spent-limit=PT30S
+timefold.model.termination.spent-limit=PT30S
 
 # Temporary comment this out to detect bugs in your code (lowers performance)
 # quarkus.timefold.solver.environment-mode=FULL_ASSERT
@@ -67,5 +67,5 @@ quarkus.swagger-ui.always-include=true
 ########################
 
 # Effectively disable spent-time termination in favor of the best-score-limit
-%test.ai.timefold.platform.termination.spent-limit=PT1H
+%test.timefold.model.termination.spent-limit=PT1H
 %test.quarkus.timefold.solver.termination.best-score-limit=0hard/*medium/*soft


### PR DESCRIPTION
## Summary
- Replaces deprecated `ai.timefold.platform.termination.spent-limit` with `timefold.model.termination.spent-limit` in the three quickstarts that still used the old key.
- Values are unchanged (PT30S in prod; PT1H under `%test` where that override already existed).

Closes #1176

## Files
- `getting-started/service`
- `use-cases/bed-allocation`
- `use-cases/conference-scheduling`

No remaining `ai.timefold.platform.*` keys in the repo. Other `ai.timefold.model.default-config.termination.*` / `ai.timefold.storage.*` keys were left as-is because they were not in the deprecation warnings on the issue.

## Test plan
- [x] `mvn test` in `use-cases/conference-scheduling`
- [x] `mvn test` in `use-cases/bed-allocation`

Made with [Cursor](https://cursor.com)